### PR TITLE
[Feature] Add part method of Executor

### DIFF
--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -38,12 +38,15 @@ class ChannelController {
     void update(int mode, const std::string &name);
     void updateTopic(Channel *channel, const std::string &name);
 
-    // update
-    void updateInsertChannel(Channel *channel, Client *client,
-                             bool is_operator);
-    void updateEraseChannel(Channel *channel, Client *client);
+    /**
+     * @brief insert Client to Channel's _clientList
+     */
+    void insertClient(Channel *channel, Client *client, bool is_operator);
 
-    // void updateChannel(Channel *channel, Client *client, bool is_insert);
+    /**
+     * @brief erase Client to Channel's _clientList
+     */
+    void eraseClient(Channel *channel, Client *client);
 };
 
 }  // namespace ft

--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -39,7 +39,8 @@ class ChannelController {
     void updateTopic(Channel *channel, const std::string &name);
 
     // update
-    void updateInsertChannel(Channel *channel, Client *client);
+    void updateInsertChannel(Channel *channel, Client *client,
+                             bool is_operator);
     void updateEraseChannel(Channel *channel, Client *client);
 
     // void updateChannel(Channel *channel, Client *client, bool is_insert);

--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -13,7 +13,7 @@ class ChannelController {
     // std::string & 되나
     typedef std::map<std::string, Channel> Channels;
     // TODO Consider client_iterator || Client *
-    typedef Channels::iterator client_iterator;
+    typedef Channels::iterator channel_iterator;
     // typedef std::pair<client_iterator, bool>;
 
    private:

--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -39,8 +39,10 @@ class ChannelController {
     void updateTopic(Channel *channel, const std::string &name);
 
     // update
-    void updateChannel(Channel *channel, Client *client, bool is_operator,
-                       bool is_insert);
+    void updateInsertChannel(Channel *channel, Client *client);
+    void updateEraseChannel(Channel *channel, Client *client);
+
+    // void updateChannel(Channel *channel, Client *client, bool is_insert);
 };
 
 }  // namespace ft

--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -39,7 +39,8 @@ class ClientController {
     void update(Client* client, const std::string& nickname);
 
     // ClinetController -> updateChannel
-    void updateClient(Client* client, Channel* channel, bool is_insert);
+    void updateInsertClient(Client* client, Channel* channel);
+    void updateEraseClient(Client* client, Channel* channel);
 };
 
 }  // namespace ft

--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -38,9 +38,15 @@ class ClientController {
     void update(int fd, const std::string& nickname);
     void update(Client* client, const std::string& nickname);
 
-    // ClinetController -> updateChannel
-    void updateInsertClient(Client* client, Channel* channel);
-    void updateEraseClient(Client* client, Channel* channel);
+    /**
+     * @brief insert Channel to Client's _channelList
+     */
+    void insertChannel(Client* client, Channel* channel);
+
+    /**
+     * @brief erase Channel to Client's _channelList
+     */
+    void eraseChannel(Client* client, Channel* channel);
 };
 
 }  // namespace ft

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -26,8 +26,7 @@ class Executor {
     Executor &operator=(const Executor &ref);
 
     // method
-    // TODO : findClient(int fd);  // kevent - fd, udata  -> recv -> JOIN #abc
-    // void deleteClient(std::string nickname);
+    void part(int fd, CmdLine channels);
     // void joinClient(std::string nickname, std::string channel_name);
 
     void join(int fd, CmdLine cmd_line);

--- a/include/entity/Channel.hpp
+++ b/include/entity/Channel.hpp
@@ -50,8 +50,8 @@ class Channel {
     void setMode(int mode);
 
     // update
-    void updateInsertClientList(Client *client, bool is_operator);
-    void updateEraseClientList(Client *client);
+    void insertClient(Client *client, bool is_operator);
+    void eraseClient(Client *client);
     // void updateClientList(Client *client, bool is_insert);
 
     bool isOperator(Client *client);

--- a/include/entity/Channel.hpp
+++ b/include/entity/Channel.hpp
@@ -50,7 +50,7 @@ class Channel {
     void setMode(int mode);
 
     // update
-    void updateInsertClientList(Client *client);
+    void updateInsertClientList(Client *client, bool is_operator);
     void updateEraseClientList(Client *client);
     // void updateClientList(Client *client, bool is_insert);
 

--- a/include/entity/Channel.hpp
+++ b/include/entity/Channel.hpp
@@ -21,6 +21,7 @@ enum e_type {
 class Channel {
    public:
     typedef std::set<Client *> ClientList;
+    typedef std::set<Client *>::iterator client_list_iterator;
 
    private:
     std::string _name;
@@ -49,11 +50,15 @@ class Channel {
     void setMode(int mode);
 
     // update
-    void updateClientList(Client *client, bool is_operator, bool is_insert);
+    void updateInsertClientList(Client *client);
+    void updateEraseClientList(Client *client);
+    // void updateClientList(Client *client, bool is_insert);
 
-    bool is_invite_mode();
-    bool is_topic_mode();
-    bool is_ban_mode();
+    bool isOperator(Client *client);
+
+    bool isInviteMode();
+    bool isTopicMode();
+    bool isBanMode();
 
     bool operator==(const Channel &other) const;
     bool operator!=(const Channel &other) const;

--- a/include/entity/Client.hpp
+++ b/include/entity/Client.hpp
@@ -41,8 +41,8 @@ class Client : public ConnectSocket {
     void setRealname(const std::string &realname);
 
     // update
-    void updateInsertChannelList(Channel *channel);
-    void updateEraseChannelList(Channel *channel);
+    void insertChannel(Channel *channel);
+    void eraseChannel(Channel *channel);
 
     // compare operators
     bool operator==(const Client &other) const;

--- a/include/entity/Client.hpp
+++ b/include/entity/Client.hpp
@@ -41,7 +41,8 @@ class Client : public ConnectSocket {
     void setRealname(const std::string &realname);
 
     // update
-    void updateChannelList(Channel *channel, bool is_insert);
+    void updateInsertChannelList(Channel *channel);
+    void updateEraseChannelList(Channel *channel);
 
     // compare operators
     bool operator==(const Client &other) const;

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -20,11 +20,15 @@ ChannelController &ChannelController::operator=(const ChannelController &ref) {
 }
 
 Channel *ChannelController::find(const Channel *channel) {
-    return &(_channels.find(channel->getName())->second);
+    channel_iterator iter = _channels.find(channel->getName());
+    if (iter == _channels.end()) return NULL;
+    return &(iter->second);
 }
 
 Channel *ChannelController::find(const std::string &name) {
-    return &(_channels.find(name)->second);
+    channel_iterator iter = _channels.find(name);
+    if (iter == _channels.end()) return NULL;
+    return &(iter->second);
 }
 
 void ChannelController::create(const Channel *channel) {
@@ -45,7 +49,8 @@ void ChannelController::update(int mode, Channel *channel) {
     channel->setMode(mode);
 }
 void ChannelController::update(int mode, const std::string &name) {
-    find(name)->setMode(mode);
+    Channel *target = find(name);
+    if (target) return target->setMode(mode);
 }
 void ChannelController::updateTopic(Channel *channel,
                                     const std::string &topic) {

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -59,11 +59,11 @@ void ChannelController::updateTopic(Channel *channel,
 
 void ChannelController::insertClient(Channel *channel, Client *client,
                                      bool is_operator) {
-    channel->updateInsertClientList(client, is_operator);
+    channel->insertClient(client, is_operator);
 }
 
 void ChannelController::eraseClient(Channel *channel, Client *client) {
-    channel->updateEraseClientList(client);
+    channel->eraseClient(client);
     if (channel->getOperators().size() + channel->getRegulars().size() == 0) {
         del(channel);
     }

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -57,12 +57,12 @@ void ChannelController::updateTopic(Channel *channel,
     channel->setTopic(topic);
 }
 
-void ChannelController::updateInsertChannel(Channel *channel, Client *client,
-                                            bool is_operator) {
+void ChannelController::insertClient(Channel *channel, Client *client,
+                                     bool is_operator) {
     channel->updateInsertClientList(client, is_operator);
 }
 
-void ChannelController::updateEraseChannel(Channel *channel, Client *client) {
+void ChannelController::eraseClient(Channel *channel, Client *client) {
     channel->updateEraseClientList(client);
     if (channel->getOperators().size() + channel->getRegulars().size() == 0) {
         del(channel);

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -52,8 +52,9 @@ void ChannelController::updateTopic(Channel *channel,
     channel->setTopic(topic);
 }
 
-void ChannelController::updateInsertChannel(Channel *channel, Client *client) {
-    channel->updateInsertClientList(client);
+void ChannelController::updateInsertChannel(Channel *channel, Client *client,
+                                            bool is_operator) {
+    channel->updateInsertClientList(client, is_operator);
 }
 
 void ChannelController::updateEraseChannel(Channel *channel, Client *client) {

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -52,9 +52,15 @@ void ChannelController::updateTopic(Channel *channel,
     channel->setTopic(topic);
 }
 
-void ChannelController::updateChannel(Channel *channel, Client *client,
-                                      bool is_operator, bool is_insert) {
-    channel->updateClientList(client, is_operator, is_insert);
+void ChannelController::updateInsertChannel(Channel *channel, Client *client) {
+    channel->updateInsertClientList(client);
+}
+
+void ChannelController::updateEraseChannel(Channel *channel, Client *client) {
+    channel->updateEraseClientList(client);
+    if (channel->getOperators().size() + channel->getRegulars().size() == 0) {
+        del(channel);
+    }
 }
 
 }  // namespace ft

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>  // std::make_pair
 
+#include "entity/Channel.hpp"
 #include "entity/Client.hpp"
 
 namespace ft {
@@ -99,7 +100,7 @@ void ClientController::update(int fd, const std::string &nickname) {
 
     if (client) {  // valid
         if (find(nickname)) {
-            // no change
+            // no change (already exist)
         } else {
             // change nickname
             client->setNickname(nickname);
@@ -110,15 +111,18 @@ void ClientController::update(int fd, const std::string &nickname) {
 
 void ClientController::update(Client *client, const std::string &nickname) {
     if (find(nickname)) {
-        // no change
+        // no change (already exist)
     } else {
         client->setNickname(nickname);
     }
 }
 
-void ClientController::updateClient(Client *client, Channel *channel,
-                                    bool is_insert) {
-    client->updateChannelList(channel, is_insert);
+void ClientController::updateInsertClient(Client *client, Channel *channel) {
+    client->updateInsertChannelList(channel);
+}
+
+void ClientController::updateEraseClient(Client *client, Channel *channel) {
+    client->updateEraseChannelList(channel);
 }
 
 }  // namespace ft

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -119,12 +119,12 @@ void ClientController::update(Client *client, const std::string &nickname) {
     }
 }
 
-void ClientController::updateInsertClient(Client *client, Channel *channel) {
-    client->updateInsertChannelList(channel);
+void ClientController::insertChannel(Client *client, Channel *channel) {
+    client->insertChannel(channel);
 }
 
-void ClientController::updateEraseClient(Client *client, Channel *channel) {
-    client->updateEraseChannelList(channel);
+void ClientController::eraseChannel(Client *client, Channel *channel) {
+    client->eraseChannel(channel);
 }
 
 }  // namespace ft

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -26,11 +26,13 @@ ClientController &ClientController::operator=(const ClientController &ref) {
  */
 Client *ClientController::find(const int fd) {
     client_iterator iter = _clients.find(fd);
+    if (iter == _clients.end()) return NULL;
     return &(iter->second);
 }
 
 Client *ClientController::find(const Client *client) {
     client_iterator iter = _clients.find(client->getFd());
+    if (iter == _clients.end()) return NULL;
     return &(iter->second);
 }
 

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -26,8 +26,8 @@ void Executor::part(int fd, CmdLine channels) {
         // 하나의 channel에서 part
         channel = channel_controller.find(*iter);
         if (channel) {
-            client_controller.updateEraseClient(target, channel);
-            channel_controller.updateEraseChannel(channel, target);
+            client_controller.eraseChannel(target, channel);
+            channel_controller.eraseClient(channel, target);
         } else {
             // CHECK there are no channel name -> break?
         }
@@ -54,11 +54,11 @@ void Executor::join(int fd, CmdLine cmd_line) {
             Channel *channel = channel_controller.find(*iter);
             if (channel == NULL) {
                 channel_controller.create(*iter);
-                channel_controller.updateInsertChannel(channel, client, true);
+                channel_controller.insertClient(channel, client, true);
             } else {
-                channel_controller.updateInsertChannel(channel, client, false);
+                channel_controller.insertClient(channel, client, false);
             }
-            client_controller.updateInsertClient(client, channel);
+            client_controller.insertChannel(client, channel);
         }
     }
 }

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -66,13 +66,5 @@ void Executor::join(int fd, CmdLine cmd_line) {
 void Executor::mode(int fd, std::string channel, e_mode mode) {
     channel_controller.update(mode, channel);
 }
-// void Executor::part(int fd, CmdLine channels) {
-//     //
-//     Client *target = client_controller.find(fd);
-//     cmd_iterator iter = channels.begin();
-
-//         for
-//             client_controller.updateClient(target, );
-// }
 
 }  // namespace ft

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -1,5 +1,7 @@
 #include "controller/Executor.hpp"
 
+#include "entity/Channel.hpp"
+
 namespace ft {
 Executor::Executor() {}
 
@@ -9,27 +11,28 @@ Executor::~Executor() {}
 
 Executor &Executor::operator=(const Executor &ref) { return (*this); }
 
-//// /quit -> 모든 채널에서 해당 client 삭제
-// void Executor::deleteClient(std::string nickname) {
-//     // find -> Client -> channels
+/**
+ * @brief part channels
+ *
+ * @param fd
+ * @param channels 여러 개의 channel
+ */
+void Executor::part(int fd, CmdLine channels) {
+    Client *target = client_controller.find(fd);
+    Channel *channel;
+    cmd_iterator iter = channels.begin();
 
-//    Client *client = client_controller.find(nickname);
-//    ChannelList channels;
-
-//    if (client != NULL) {
-//        client_controller.del(nickname);
-//        channels = client.getChannels();  // channel list
-//        // int channel_cnt = client.getChannels().size();
-
-//        for (channel_iterator i = channels.begin(); i != channels.end(); ++i)
-//        {
-//            // 해당 client가 가입된 channel에서 client 삭제
-//            channel_controller.delete();
-//        }
-//    }
-//    // client_controller channel list -> delete
-//    // channel_controller.delete();
-//}
+    for (; iter != channels.end(); ++iter) {  // 여러 개의 channel
+        // 하나의 channel에서 part
+        channel = channel_controller.find(*iter);
+        if (channel) {
+            client_controller.updateEraseClient(target, channel);
+            channel_controller.updateEraseChannel(channel, target);
+        } else {
+            // CHECK there are no channel name -> break?
+        }
+    }
+}
 
 // kenvent.ident -> fd, kevent.udata
 // client,channel,
@@ -51,13 +54,9 @@ void Executor::join(int fd, CmdLine cmd_line) {
             Channel *channel = channel_controller.find(*iter);
             if (channel == NULL) {
                 channel_controller.create(*iter);
-                channel_controller.updateChannel(channel, client, true,
-                                                 true);  // oeprator
-            } else {
-                channel_controller.updateChannel(channel, client, false,
-                                                 true);  // regular
             }
-            client_controller.updateClient(client, channel, true);
+            channel_controller.updateInsertChannel(channel, client);
+            client_controller.updateInsertClient(client, channel);
         }
     }
 }
@@ -65,5 +64,13 @@ void Executor::join(int fd, CmdLine cmd_line) {
 void Executor::mode(int fd, std::string channel, e_mode mode) {
     channel_controller.update(mode, channel);
 }
+// void Executor::part(int fd, CmdLine channels) {
+//     //
+//     Client *target = client_controller.find(fd);
+//     cmd_iterator iter = channels.begin();
+
+//         for
+//             client_controller.updateClient(target, );
+// }
 
 }  // namespace ft

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -54,8 +54,10 @@ void Executor::join(int fd, CmdLine cmd_line) {
             Channel *channel = channel_controller.find(*iter);
             if (channel == NULL) {
                 channel_controller.create(*iter);
+                channel_controller.updateInsertChannel(channel, client, true);
+            } else {
+                channel_controller.updateInsertChannel(channel, client, false);
             }
-            channel_controller.updateInsertChannel(channel, client);
             client_controller.updateInsertClient(client, channel);
         }
     }

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -38,7 +38,7 @@ void Channel::setMode(int mode) {
 }
 
 // update
-void Channel::updateInsertClientList(Client *client, bool is_operator) {
+void Channel::insertClient(Client *client, bool is_operator) {
     // if (isOperator(client)) {
     //     _operators.insert(client);
     // } else {
@@ -49,7 +49,7 @@ void Channel::updateInsertClientList(Client *client, bool is_operator) {
         _regulars.insert(client);
 }
 
-void Channel::updateEraseClientList(Client *client) {
+void Channel::eraseClient(Client *client) {
     if (isOperator(client)) {
         _operators.erase(client);
     } else {

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -38,24 +38,33 @@ void Channel::setMode(int mode) {
 }
 
 // update
-void Channel::updateClientList(Client *client, bool is_operator,
-                               bool is_insert) {
-    if (is_operator) {
-        if (is_insert)
-            _operators.insert(client);
-        else
-            _operators.erase(client);
+void Channel::updateInsertClientList(Client *client) {
+    if (isOperator(client)) {
+        _operators.insert(client);
     } else {
-        if (is_insert)
-            _regulars.insert(client);
-        else
-            _regulars.erase(client);
+        _regulars.insert(client);
     }
 }
 
-bool Channel::is_invite_mode() { return (_mode & (INVITE_ONLY_T - 1)); }
-bool Channel::is_topic_mode() { return (_mode & (TOPIC_PRIV_T - 1)); }
-bool Channel::is_ban_mode() { return (_mode & (BAN_T - 1)); }
+void Channel::updateEraseClientList(Client *client) {
+    if (isOperator(client)) {
+        _operators.erase(client);
+    } else {
+        _regulars.erase(client);
+    }
+}
+
+bool Channel::isInviteMode() { return (_mode & (INVITE_ONLY_T - 1)); }
+bool Channel::isTopicMode() { return (_mode & (TOPIC_PRIV_T - 1)); }
+bool Channel::isBanMode() { return (_mode & (BAN_T - 1)); }
+bool Channel::isOperator(Client *client) {
+    client_list_iterator iter = _operators.find(client);
+
+    if (*iter)
+        return true;
+    else
+        return false;
+}
 
 bool Channel::operator==(const Channel &other) const {
     return (_name == other._name);

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -38,12 +38,15 @@ void Channel::setMode(int mode) {
 }
 
 // update
-void Channel::updateInsertClientList(Client *client) {
-    if (isOperator(client)) {
+void Channel::updateInsertClientList(Client *client, bool is_operator) {
+    // if (isOperator(client)) {
+    //     _operators.insert(client);
+    // } else {
+    // }
+    if (is_operator)
         _operators.insert(client);
-    } else {
+    else
         _regulars.insert(client);
-    }
 }
 
 void Channel::updateEraseClientList(Client *client) {

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -60,13 +60,9 @@ void Channel::updateEraseClientList(Client *client) {
 bool Channel::isInviteMode() { return (_mode & (INVITE_ONLY_T - 1)); }
 bool Channel::isTopicMode() { return (_mode & (TOPIC_PRIV_T - 1)); }
 bool Channel::isBanMode() { return (_mode & (BAN_T - 1)); }
-bool Channel::isOperator(Client *client) {
-    client_list_iterator iter = _operators.find(client);
 
-    if (*iter)
-        return true;
-    else
-        return false;
+bool Channel::isOperator(Client *client) {
+    return _operators.find(client) != _operators.end() ? true : false;
 }
 
 bool Channel::operator==(const Channel &other) const {

--- a/src/entity/Client.cpp
+++ b/src/entity/Client.cpp
@@ -23,14 +23,12 @@ void Client::setHostname(const std::string &hostname) { _hostname = hostname; }
 void Client::setRealname(const std::string &realname) { _realname = realname; }
 
 // update
-void Client::updateChannelList(Channel *channel, bool is_insert) {
-    if (is_insert) {
-        // insert
-        _channel_list.insert(channel);
-    } else {
-        // erase
-        _channel_list.erase(channel);
-    }
+void Client::updateInsertChannelList(Channel *channel) {
+    _channel_list.insert(channel);
+}
+
+void Client::updateEraseChannelList(Channel *channel) {
+    _channel_list.erase(channel);
 }
 
 // compare operators

--- a/src/entity/Client.cpp
+++ b/src/entity/Client.cpp
@@ -23,13 +23,9 @@ void Client::setHostname(const std::string &hostname) { _hostname = hostname; }
 void Client::setRealname(const std::string &realname) { _realname = realname; }
 
 // update
-void Client::updateInsertChannelList(Channel *channel) {
-    _channel_list.insert(channel);
-}
+void Client::insertChannel(Channel *channel) { _channel_list.insert(channel); }
 
-void Client::updateEraseChannelList(Channel *channel) {
-    _channel_list.erase(channel);
-}
+void Client::eraseChannel(Channel *channel) { _channel_list.erase(channel); }
 
 // compare operators
 bool Client::operator==(const Client &other) const {


### PR DESCRIPTION
## 개요
- Executor의 part method 구현

## 작업내용
- controller의 update 함수를 insert, erase 2개로 분기
- entity의 client, channel의 update 함수를 insert, erase 2개로 분기
- controller와 entity의 insert 함수에는 bool is_operator 파라미터 추가
- controller와 entity의 insert, erase 함수명 수정

## 주의사항
- *::find() 함수 사용시 return 값 주의 필요 (iterator인 경우, null로 확인 불가능)
