### PR TITLE
[Feature] Executor::privmsg 함수 구현

### DIFF
--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -26,16 +26,16 @@ class ChannelController {
     ChannelController &operator=(const ChannelController &ref);
 
     Channel *find(const Channel *channel);
-    Channel *find(const std::string &name);
+    Channel *find(const std::string &channel_name);
 
     void create(const Channel *channel);
-    void create(const std::string &name);
+    void create(const std::string &channel_name);
 
     void del(const Channel *channel);
-    void del(const std::string &name);
+    void del(const std::string &channel_name);
 
     void updateMode(int mode, Channel *channel);
-    void updateMode(int mode, const std::string &name);
+    void updateMode(int mode, const std::string &channel_name);
     void updateTopic(Client *client, Channel *channel,
                      const std::string &topic);
 

--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -28,11 +28,11 @@ class ChannelController {
     Channel *find(const Channel *channel);
     Channel *find(const std::string &channel_name);
 
-    void create(const Channel *channel);
-    void create(const std::string &channel_name);
+    void insert(const Channel *channel);
+    void insert(const std::string &channel_name);
 
-    void del(const Channel *channel);
-    void del(const std::string &channel_name);
+    void erase(const Channel *channel);
+    void erase(const std::string &channel_name);
 
     void updateMode(int mode, Channel *channel);
     void updateMode(int mode, const std::string &channel_name);

--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -29,13 +29,11 @@ class ClientController {
     Client* find(const Client* client);
     Client* find(const std::string& nickname);
 
-    void create(const Client* client);
-    void create(int fd, const Client* client);
-    Client* create(int fd);
+    Client* insert(int fd);
 
-    void del(const Client* client);
-    void del(const std::string& nickname);
-    void del(int fd);
+    void erase(const Client* client);
+    void erase(const std::string& nickname);
+    void erase(int fd);
 
     void updateNickname(int fd, const std::string& nickname);
     void updateNickname(Client* client, const std::string& nickname);

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -31,6 +31,9 @@ class Executor {
 
     void part(int fd, CmdLine channels);
     // void joinClient(std::string nickname, std::string channel_name);
+    void connect(int fd, Udata *udata, CmdLine cmd_line);
+    void connect(int fd, Udata *udata);
+    // int joinClient(std::string nickname, std::string channel_name);
 
     void join(int fd, CmdLine cmd_line);
     void mode(int fd, std::string channel, e_mode mode);  // std::string info
@@ -40,13 +43,16 @@ class Executor {
 
     void kick(int fd, std::string channel, std::string nickname,
               std::string comment);
-    void pass(Client *new_client, std::string password, std::string server_password);
+    void pass(Client *new_client, std::string password,
+              std::string server_password);
     void user(Client *new_client, std::string username, std::string hostname,
               std::string server, std::string realname);
     void nick(Client *new_client, std::string nickname);
     void nick(int fd, std::string nickname);
 
     void quit(int fd, std::string msg);
+
+    void privmsg(CmdLine receivers, std::string msg);
 };
 
 // Executor -> Server data update

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -28,15 +28,12 @@ class Executor {
 
     // method
     Client *creatClient(int fd);
-
     void part(int fd, CmdLine channels);
-    // void joinClient(std::string nickname, std::string channel_name);
-    void connect(int fd, Udata *udata, CmdLine cmd_line);
-    void connect(int fd, Udata *udata);
     // int joinClient(std::string nickname, std::string channel_name);
 
     void join(int fd, CmdLine cmd_line);
-    void mode(int fd, std::string channel, e_mode mode);  // std::string info
+    void mode(int fd, std::string channel,
+              e_mode mode);  // std::string info
     void topic(int fd, std::string channel,
                std::string topic);  // fd -> client ...
     void invite(int fd, std::string nickname, std::string channel);
@@ -52,7 +49,11 @@ class Executor {
 
     void quit(int fd, std::string msg);
 
-    void privmsg(CmdLine receivers, std::string msg);
+    void privmsg(Client *client, CmdLine receivers, std::string msg);
+
+   private:
+    // exclude client
+    void broadcast(Channel *channel, std::string msg, Client *client = NULL);
 };
 
 // Executor -> Server data update

--- a/include/core/Udata.hpp
+++ b/include/core/Udata.hpp
@@ -46,7 +46,7 @@ struct invite_params : public params {
 struct kick_params : public params {
     std::string channel;
     std::string user;
-    std::string comment; // optional
+    std::string comment;  // optional
 };
 struct topic_params : public params {
     std::string channel;
@@ -70,7 +70,9 @@ struct Udata {
     e_cmd command;
     params *params;
     std::string msg;
-    Client *src;
+    Client *src;  // CHECK src??
+
+    // Client
 
     Udata();
     Udata(const Udata &copy);

--- a/include/entity/Client.hpp
+++ b/include/entity/Client.hpp
@@ -13,7 +13,7 @@ class Channel;
 class Client : public ConnectSocket {
    public:
     typedef std::set<Channel *> ChannelList;
-    typedef std::set<Channel *>::iterator channel_list_ieterator;
+    typedef std::set<Channel *>::iterator channel_list_iterator;
 
    private:
     // typedef typename std::set<Channel *>::iterator channel_iterator;

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -32,19 +32,19 @@ Channel *ChannelController::find(const std::string &channel_name) {
     return &(iter->second);
 }
 
-void ChannelController::create(const Channel *channel) {
+void ChannelController::insert(const Channel *channel) {
     _channels.insert(std::make_pair(channel->getName(), *channel));
 }
-void ChannelController::create(const std::string &channel_name) {
+void ChannelController::insert(const std::string &channel_name) {
     Channel new_channel(channel_name);  // TODO : init mode
     _channels.insert(std::make_pair(channel_name, new_channel));
 }
 
-void ChannelController::del(const Channel *channel) {  // const
+void ChannelController::erase(const Channel *channel) {  // const
     _channels.erase(channel->getName());
 }
 
-void ChannelController::del(const std::string &channel_name) {
+void ChannelController::erase(const std::string &channel_name) {
     _channels.erase(channel_name);
 }
 
@@ -96,7 +96,7 @@ void ChannelController::insertClient(Channel *channel, Client *client,
 void ChannelController::eraseClient(Channel *channel, Client *client) {
     channel->eraseClient(client);
     if (channel->getOperators().size() + channel->getRegulars().size() == 0) {
-        del(channel);
+        erase(channel);
     }
 }
 

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -26,8 +26,8 @@ Channel *ChannelController::find(const Channel *channel) {
     return &(iter->second);
 }
 
-Channel *ChannelController::find(const std::string &name) {
-    channel_iterator iter = _channels.find(name);
+Channel *ChannelController::find(const std::string &channel_name) {
+    channel_iterator iter = _channels.find(channel_name);
     if (iter == _channels.end()) return NULL;
     return &(iter->second);
 }
@@ -35,22 +35,24 @@ Channel *ChannelController::find(const std::string &name) {
 void ChannelController::create(const Channel *channel) {
     _channels.insert(std::make_pair(channel->getName(), *channel));
 }
-void ChannelController::create(const std::string &name) {
-    Channel new_channel(name);  // TODO : init mode
-    _channels.insert(std::make_pair(name, new_channel));
+void ChannelController::create(const std::string &channel_name) {
+    Channel new_channel(channel_name);  // TODO : init mode
+    _channels.insert(std::make_pair(channel_name, new_channel));
 }
 
 void ChannelController::del(const Channel *channel) {  // const
     _channels.erase(channel->getName());
 }
 
-void ChannelController::del(const std::string &name) { _channels.erase(name); }
+void ChannelController::del(const std::string &channel_name) {
+    _channels.erase(channel_name);
+}
 
 void ChannelController::updateMode(int mode, Channel *channel) {
     channel->setMode(mode);
 }
-void ChannelController::updateMode(int mode, const std::string &name) {
-    Channel *target = find(name);
+void ChannelController::updateMode(int mode, const std::string &channel_name) {
+    Channel *target = find(channel_name);
     if (target) return target->setMode(mode);
 }
 
@@ -100,7 +102,7 @@ void ChannelController::eraseClient(Channel *channel, Client *client) {
 
 void ChannelController::eraseClient(Client *client) {
     Client::ChannelList channel_list = client->getChannelList();
-    Client::channel_list_ieterator iter = channel_list.begin();
+    Client::channel_list_iterator iter = channel_list.begin();
 
     for (; iter != channel_list.end(); ++iter) {
         eraseClient(*iter, client);

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -49,19 +49,11 @@ Client *ClientController::find(const std::string &nickname) {
 }
 
 /**
- * @brief create client to _clients
+ * @brief insert client to _clients
  *
  * @param client
  */
-void ClientController::create(const Client *client) {
-    _clients.insert(std::make_pair(client->getFd(), *client));
-}
-
-void ClientController::create(int fd, const Client *client) {
-    _clients.insert(std::make_pair(fd, *client));
-}
-
-Client *ClientController::create(int fd) {
+Client *ClientController::insert(int fd) {
     Client client;
     pair p = _clients.insert(std::make_pair(fd, client));
     return &(p.first->second);
@@ -72,11 +64,11 @@ Client *ClientController::create(int fd) {
  *
  * @param client
  */
-void ClientController::del(const Client *client) {
+void ClientController::erase(const Client *client) {
     _clients.erase(client->getFd());
 }
 
-void ClientController::del(const std::string &nickname) {
+void ClientController::erase(const std::string &nickname) {
     Client *target = find(nickname);
 
     if (target) {
@@ -86,7 +78,7 @@ void ClientController::del(const std::string &nickname) {
     }
 }
 
-void ClientController::del(int fd) {
+void ClientController::erase(int fd) {
     Client *target = find(fd);
 
     if (target) {

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -173,4 +173,15 @@ void Executor::kick(int fd, std::string channel, std::string nickname,
     }
 }
 
+void Executor::privmsg(CmdLine receivers, std::string msg) {
+    //
+    cmd_iterator iter = receivers.begin();
+    for (; iter != receivers.end(); ++iter) {
+        // make response?
+        // write event 등록 -> server::run에서 다음 loop 돌 때
+        // monitorEvent()에서 감지
+        // EventHandler::registerEvent()
+    }
+}
+
 }  // namespace ft

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -193,8 +193,13 @@ void Executor::privmsg(Client *client, CmdLine receivers, std::string msg) {
             }
         } else {  // user
             name = *iter;
-            send(client_controller.find(name)->getFd(), msg.c_str(),
-                 msg.length(), 0);
+            Client *receiver = client_controller.find(name);
+            if (receiver) {
+                send(client_controller.find(name)->getFd(), msg.c_str(),
+                     msg.length(), 0);
+            } else {
+                // 401 user3 wow :No such nick
+            }
         }
     }
 }

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -12,7 +12,7 @@ Executor::~Executor() {}
 
 Executor &Executor::operator=(const Executor &ref) { return (*this); }
 
-Client *Executor::creatClient(int fd) { return client_controller.create(fd); }
+Client *Executor::creatClient(int fd) { return client_controller.insert(fd); }
 
 /**
  * @brief part channels
@@ -56,7 +56,7 @@ void Executor::join(int fd, CmdLine cmd_line) {
         if (iter->front() == '#') {
             Channel *channel = channel_controller.find(*iter);
             if (channel == NULL) {
-                channel_controller.create(*iter);
+                channel_controller.insert(*iter);
                 channel_controller.insertClient(channel, client, true);
             } else {
                 channel_controller.insertClient(channel, client, false);
@@ -148,7 +148,7 @@ void Executor::quit(int fd, std::string msg) {
     // TODO send messages (PRIVMSG)
     // channel_controller.
 
-    client_controller.del(fd);
+    client_controller.erase(fd);
     channel_controller.eraseClient(client);
 }
 void Executor::kick(int fd, std::string channel, std::string nickname,
@@ -175,15 +175,14 @@ void Executor::kick(int fd, std::string channel, std::string nickname,
 
 void Executor::privmsg(Client *client, CmdLine receivers, std::string msg) {
     std::string name;
-
     cmd_iterator iter = receivers.begin();
+
     for (; iter != receivers.end(); ++iter) {
         if (iter->at(0) == '#') {  // channel
             name = (*iter).at(1);
             Channel *channel = channel_controller.find(name);
             if (channel) {
                 if (channel->isOnChannel(client)) {
-                    // send
                     // user3!hannah@127.0.0.1 PRIVMSG #testchannel :hi
                     broadcast(channel, msg, client);
                 } else {


### PR DESCRIPTION
## 개요
- Executor::privmsg 함수 구현

## 작업내용
- privmsg, quit, nick 등의 함수에서 사용할 Executor::broadcast private 함수 추가

## 주의사항
- Executor의 모든 public 함수의 return 값 int numeric_replie로 수정 필요