### PR TITLE
[Feature] Add send_buf, Mod handleWrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ fclean: clean
 re: fclean all
 
 .PHONY	: debug
-debug	: fclean
+debug	:
 	@make DEBUG=1 all
 
 .PHONY	: leaks

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ fclean: clean
 re: fclean all
 
 .PHONY	: debug
-debug	:
+debug	: fclean
 	@make DEBUG=1 all
 
 .PHONY	: leaks

--- a/include/core/EventHandler.hpp
+++ b/include/core/EventHandler.hpp
@@ -4,12 +4,13 @@
 #include <sys/event.h>
 
 #include <vector>
+
 #include "Udata.hpp"
 
 namespace ft {
 
 class EventHandler {
- protected:
+   protected:
     typedef struct kevent Event;
     typedef std::vector<Event> EventList;
 
@@ -21,7 +22,7 @@ class EventHandler {
     Event _ev_list[_max_event];
     EventList _change_list;
 
- public:
+   public:
     EventHandler();
     EventHandler(const EventHandler &copy);
     virtual ~EventHandler();
@@ -37,7 +38,7 @@ class EventHandler {
     virtual void handleRead(int event_idx) = 0;
     virtual void handleExecute(int event_idx) = 0;
     virtual void handleWrite(int event_idx) = 0;
-    virtual void handleIdel(int event_idx) = 0;
+    virtual void handleTimeout(int event_idx) = 0;
 };
 }  // namespace ft
 

--- a/include/core/EventHandler.hpp
+++ b/include/core/EventHandler.hpp
@@ -37,7 +37,7 @@ class EventHandler {
     virtual void handleRead(int event_idx) = 0;
     virtual void handleExecute(int event_idx) = 0;
     virtual void handleWrite(int event_idx) = 0;
-
+    virtual void handleIdel(int event_idx) = 0;
 };
 }  // namespace ft
 

--- a/include/core/Parser.hpp
+++ b/include/core/Parser.hpp
@@ -1,32 +1,32 @@
 #ifndef PARSER_HPP
 #define PARSER_HPP
 
+#include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
-#include <iostream>
-#include "Type.hpp"
-#include "Udata.hpp"
 
+#include "core/Type.hpp"
+#include "core/Udata.hpp"
+#include "core/utility.hpp"
 namespace ft {
-
-std::vector<std::string> split(std::string str, char delimiter);
-std::vector<std::string> split(std::istringstream &stream, char delimiter);
 
 class Parser {
    private:
     enum { TOKEN, MSG };
     std::istringstream tokenStream;
     std::string token;
+
    protected:
     int getToken(int flag);
     bool isEOF();
 
     static bool validSpecial(char c);
     static std::string &validChannelName(std::string &channel);
-    static std::vector<std::string> &validChannelName(std::vector<std::string> &channels);
+    static std::vector<std::string> &validChannelName(
+        std::vector<std::string> &channels);
     static std::string &validNickName(std::string &nickname);
-    
+
    public:
     void parseQuit(e_cmd &cmd, params *&params);
     void parsePass(e_cmd &cmd, params *&params);

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -43,6 +43,7 @@ class Server : public EventHandler {
     void handleRead(int event_idx);
     void handleExecute(int event_idx);
     void handleWrite(int event_idx);
+    void handleIdel(int event_idx);
 };
 
 }  // namespace ft

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -43,7 +43,7 @@ class Server : public EventHandler {
     void handleRead(int event_idx);
     void handleExecute(int event_idx);
     void handleWrite(int event_idx);
-    void handleIdel(int event_idx);
+    void handleTimeout(int event_idx);
 };
 
 }  // namespace ft

--- a/include/core/Socket.hpp
+++ b/include/core/Socket.hpp
@@ -1,9 +1,9 @@
 #ifndef SOCKET_HPP
 #define SOCKET_HPP
 
-#include <string>
 #include <netinet/in.h>
-#include <queue>
+
+#include <string>
 
 #include "core/Udata.hpp"
 
@@ -37,13 +37,10 @@ class ListenSocket : public SocketBase {
 class ConnectSocket : public SocketBase {
    public:
     std::string recv_buf;
-
-    // char recv_buf[BUF_SIZE];
+    std::string send_buf;
     bool auth[3];
 
    protected:
-    //    std::queue<Response> send_queue;
-
    public:
     ConnectSocket();
     ConnectSocket(const ConnectSocket &copy);
@@ -51,6 +48,7 @@ class ConnectSocket : public SocketBase {
     ConnectSocket &operator=(const ConnectSocket &ref);
 
     void createSocket(const int &listen_fd);
+
     bool isAuthenticate();
 };
 

--- a/include/core/Socket.hpp
+++ b/include/core/Socket.hpp
@@ -39,6 +39,7 @@ class ConnectSocket : public SocketBase {
     std::string recv_buf;
     std::string send_buf;
     bool auth[3];
+    long long create_time;
 
    protected:
    public:

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -8,10 +8,9 @@ enum e_event {
     READ,
     READ_MORE,
     WRITE,
-    WRITE_MORE,
     EXCUTE,
+    CLOSE,
     DEL_READ,
-    DEL_EXCUTE,
     DEL_WRITE,
     IDLE
 };

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -12,6 +12,7 @@ enum e_event {
     CLOSE,
     DEL_READ,
     DEL_WRITE,
+    TIMEOUT,
     IDLE
 };
 

--- a/include/core/utility.hpp
+++ b/include/core/utility.hpp
@@ -1,0 +1,13 @@
+#ifndef UTILITY_HPP
+#define UTILITY_HPP
+
+#include <sstream>
+#include <vector>
+
+namespace ft {
+
+std::vector<std::string> split(std::string str, char delimiter);
+std::vector<std::string> split(std::istringstream& stream, char delimiter);
+long long getTicks(void);
+}  // namespace ft
+#endif  // UTILITY_HPP

--- a/src/core/EventHandler.cpp
+++ b/src/core/EventHandler.cpp
@@ -7,6 +7,8 @@
 
 namespace ft {
 
+long getTicks(void);  // utility.cpp
+
 EventHandler::EventHandler() : _change_cnt(0) {
     _kq_fd = kqueue();
     _change_list.reserve(128);
@@ -57,6 +59,9 @@ void EventHandler::handleEvent(int event_idx) {
         case WRITE:
             handleWrite(event_idx);  // TODO
             break;
+        case IDLE:
+            handleIdel(event_idx);
+            break;
         default:
             std::cout << "client #" << _ev_list[event_idx].ident
                       << " (unknown event occured)" << std::endl;
@@ -90,6 +95,10 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
         case WRITE:
             EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
                    static_cast<void *>(udata));
+            break;
+        case IDLE:
+            EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
+                   reinterpret_cast<void *>(getTicks()));
             break;
         case DEL_READ:
             EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0,

--- a/src/core/EventHandler.cpp
+++ b/src/core/EventHandler.cpp
@@ -1,7 +1,9 @@
 #include "core/EventHandler.hpp"
-#include "core/Udata.hpp"
-#include "core/Type.hpp"
+
 #include <iostream>
+
+#include "core/Type.hpp"
+#include "core/Udata.hpp"
 
 namespace ft {
 
@@ -33,13 +35,13 @@ int EventHandler::monitorEvent() {
  */
 void EventHandler::handleEvent(int event_idx) {
     Event event = _ev_list[event_idx];
-    int action = ((Udata *) event.udata)->action;
+    Udata *udata = static_cast<Udata *>(event.udata);
 
     if (event.flags == EV_ERROR) {
         std::cerr << "EV_ERROR OCCURED" << std::endl;
         return;
     }
-    switch (action) {
+    switch (udata->action) {
         case ACCEPT:
             handleAccept();
             break;
@@ -72,34 +74,34 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
     switch (action) {
         case ACCEPT:
             EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
-                   (void *) udata);
+                   static_cast<void *>(udata));
             break;
         case CONNECT:
             EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
-                   (void *) udata);
+                   static_cast<void *>(udata));
             break;
         case READ:
             EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
-                   (void *) udata);
+                   static_cast<void *>(udata));
             break;
         case EXCUTE:
             EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
-                   (void *) udata);
+                   static_cast<void *>(udata));
         case WRITE:
             EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
-                   (void *) udata);
+                   static_cast<void *>(udata));
             break;
         case DEL_READ:
             EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0,
-                   (void *) (intptr_t) READ);
+                   static_cast<void *>(udata));
             break;
         case DEL_WRITE:
             EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0,
-                   (void *) (intptr_t) WRITE);
+                   static_cast<void *>(udata));
             break;
         case DEL_EXCUTE:
             EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0,
-                   (void *) (intptr_t) EXCUTE);
+                   static_cast<void *>(udata));
             break;
         default:
             return;

--- a/src/core/Parser.cpp
+++ b/src/core/Parser.cpp
@@ -38,9 +38,9 @@ std::vector<std::string> &Parser::validChannelName(std::vector<std::string> &cha
 }
 std::string &Parser::validNickName(std::string &nickname) {
     // <letter> { <letter> | <number> | <special> }
-    if (nickname.length() > 9) throw std::logic_error("Invalid Channel Name");
-    if (isalpha(nickname[0]))
-        throw std::logic_error("Invalid Channel Name");
+    if (nickname.length() > 9) throw std::logic_error("Invalid Nick Name");
+    if (!isalpha(nickname[0]))
+        throw std::logic_error("Invalid Nick Name");
     for (int i = 1; i < nickname.length(); i++) {
         if (!isalnum(nickname[i]) && !isSpecial(nickname[i]))
             throw std::logic_error("Invalid Channel Name");

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -9,12 +9,10 @@
 
 #include "core/Type.hpp"
 #include "core/Udata.hpp"
+#include "core/utility.hpp"
 #include "entity/Client.hpp"
 
 namespace ft {
-std::vector<std::string> split(std::string str,
-                               char Delimiter);  // 임시로 만든거
-long long getTicks(void);                        // utility.cpp
 
 void Env::parse(int argc, char **argv) {
     double d_port;

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -143,7 +143,7 @@ void Server::handleConnect(int event_idx) {
     }
     if (new_client->isAuthenticate()) {
         registerEvent(event.ident, READ, (Udata *)event.udata);
-        registerEvent(event.ident, WRITE, (Udata *)event.udata);
+        registerEvent(event.ident, WRITE, static_cast<Udata *>(event.udata));
         std::cout << "#" << event.ident << "READ event registered!"
                   << std::endl;
     }
@@ -233,14 +233,14 @@ void Server::handleExecute(int event_idx) {
 }
 
 void Server::handleWrite(int event_idx) {
-    // Udata *udata = static_cast<Udata *>(_ev_list[event_idx].udata);
+    Event &event = _ev_list[event_idx];
     std::string &send_buf =
-        static_cast<Udata *>(_ev_list[event_idx].udata)->src->send_buf;
+        static_cast<Udata *>(event.udata)->src->send_buf;
     std::cout << "write " << event_idx << std::endl;
     ssize_t n;
-    n = send(_ev_list[event_idx].ident, send_buf.c_str(), send_buf.length(), 0);
+    n = send(event.ident, send_buf.c_str(), send_buf.length(), 0);
     if (n == send_buf.length())
-        registerEvent(_ev_list[event_idx].ident, DEL_WRITE, NULL);
+        registerEvent(event.ident, DEL_WRITE, NULL);
     else if (n == -1) {
         std::cerr << "[UB] send return -1" << std::endl;
     } else {

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -14,7 +14,7 @@
 namespace ft {
 std::vector<std::string> split(std::string str,
                                char Delimiter);  // 임시로 만든거
-long getTicks(void);                             // utility.cpp
+long long getTicks(void);                        // utility.cpp
 
 void Env::parse(int argc, char **argv) {
     double d_port;
@@ -89,7 +89,7 @@ void Server::handleAccept() {
     data->src = new_client;
 
     registerEvent(new_client->getFd(), CONNECT, data);
-    registerEvent(new_client->getFd(), IDLE, data);
+    // registerEvent(new_client->getFd(), TIMEOUT, data); // TODO
 }
 
 void Server::handleConnect(int event_idx) {
@@ -190,8 +190,6 @@ void Server::handleExecute(int event_idx) {
     int numeric_replie;
     int fd = _ev_list[event_idx].ident;
 
-    registerEvent(fd, DEL_EXCUTE, udata);
-
     switch (udata->command) {
         case NICK:
             _executor.nick(client, "nickname");  // TODO nickname
@@ -231,7 +229,6 @@ void Server::handleExecute(int event_idx) {
             //      _executor.pong(fd);
             //     break;
         default:
-            return;
             break;
     }
     registerEvent(_ev_list[event_idx].ident, WRITE, udata);
@@ -253,9 +250,12 @@ void Server::handleWrite(int event_idx) {
     }
 }
 
-void Server::handleIdel(int event_idx) {
-    long start = reinterpret_cast<long>(_ev_list[event_idx].udata);
-    if (getTicks() > start + 10){
+void Server::handleTimeout(int event_idx) {
+    long long start =
+        static_cast<Udata *>(_ev_list[event_idx].udata)->src->create_time;
+    // registerEvent(_ev_list[event_idx].ident, DEL_WRITE, 0);  // 나중에고치기
+
+    if (getTicks() > start + 10000) {
         registerEvent(_ev_list[event_idx].ident, DEL_READ, 0);
         registerEvent(_ev_list[event_idx].ident, CLOSE, 0);
     }

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -74,8 +74,8 @@ void ListenSocket::createSocket(const int &port) {
 
 ConnectSocket::ConnectSocket() : SocketBase(-1) {
     create_time = getTicks();
-    recv_buf.reserve(510);
-    send_buf.reserve(510);
+    recv_buf.reserve(512);
+    send_buf.reserve(512);
 }
 ConnectSocket::ConnectSocket(const ConnectSocket &copy)
     : SocketBase(copy.getFd()) {}

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -11,6 +11,8 @@
 
 namespace ft {
 
+long long getTicks(void);  // utility.cpp
+
 /****************************************************/
 /*                  SocketBase                      */
 /****************************************************/
@@ -71,6 +73,7 @@ void ListenSocket::createSocket(const int &port) {
 /****************************************************/
 
 ConnectSocket::ConnectSocket() : SocketBase(-1) {
+    create_time = getTicks();
     recv_buf.reserve(510);
     send_buf.reserve(510);
 }

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -9,9 +9,9 @@
 #include <iostream>
 #include <stdexcept>
 
-namespace ft {
+#include "core/utility.hpp"
 
-long long getTicks(void);  // utility.cpp
+namespace ft {
 
 /****************************************************/
 /*                  SocketBase                      */

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -71,7 +71,8 @@ void ListenSocket::createSocket(const int &port) {
 /****************************************************/
 
 ConnectSocket::ConnectSocket() : SocketBase(-1) {
-    //    recv_buf = new char[BUF_SIZE];
+    recv_buf.reserve(510);
+    send_buf.reserve(510);
 }
 ConnectSocket::ConnectSocket(const ConnectSocket &copy)
     : SocketBase(copy.getFd()) {}
@@ -93,6 +94,5 @@ void ConnectSocket::createSocket(const int &listen_fd) {
 }
 
 bool ConnectSocket::isAuthenticate() { return auth[0] && auth[1] && auth[2]; }
-
 
 }  // namespace ft

--- a/src/core/utility.cpp
+++ b/src/core/utility.cpp
@@ -1,3 +1,5 @@
+#include <sys/time.h>
+
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -23,6 +25,13 @@ std::vector<std::string> split(std::istringstream &stream, char delimiter) {
         tokens.push_back(token);
     }
     return tokens;
+}
+
+long getTicks(void) {
+    struct timeval t_val;
+
+    gettimeofday(&t_val, NULL);
+    return (t_val.tv_sec + t_val.tv_usec / 1000000L);
 }
 
 }  // namespace ft

--- a/src/core/utility.cpp
+++ b/src/core/utility.cpp
@@ -27,11 +27,11 @@ std::vector<std::string> split(std::istringstream &stream, char delimiter) {
     return tokens;
 }
 
-long getTicks(void) {
+long long getTicks(void) {
     struct timeval t_val;
 
     gettimeofday(&t_val, NULL);
-    return (t_val.tv_sec + t_val.tv_usec / 1000000L);
+    return (t_val.tv_sec * 1000LL + t_val.tv_usec / 1000LL);
 }
 
 }  // namespace ft

--- a/src/core/utility.cpp
+++ b/src/core/utility.cpp
@@ -1,8 +1,7 @@
 #include <sys/time.h>
 
-#include <iostream>
-#include <sstream>
-#include <vector>
+#include <core/utility.hpp>
+#include <istream>
 
 namespace ft {
 


### PR DESCRIPTION
## 개요
- ConnectSocket::send_buf
  - std::string 으로 Excutor 에서 생성된 response를 여기에 append 해주면 됨
- Server::handleWrite
  - send_buf 가 send 된 크기를 확인
    - 다 안된 경우 substr 하여, send_buf 수정 후 다음번 handleWrite에서 처리 (kqueue에 이벤트 방치)
    - 다 된 경우 kqueue에 이벤트 삭제
## 작업내용
- use c++ cast operator
## 주의사항
- send(fd, send_buf.c_str(), send_buf.length()) == -1 경우 UB 처
  - 일단 fd가 닫힌 경우 일 수 있어서, DEL_READ와 DEL_WRITE registerEvent 해줄 예정
- access modifiers 수정
  - protected : recv_buf, send_buf ...
- [Refactoring 제안] send_buf -> send_queue
	- std::deque<std::string> send_queue, 각 element 를 str::stirng::reserve 510으로 하는건 어떤지