### PR TITLE
[Feature] executor 함수 broadcast 추가

### DIFF
--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -2,6 +2,7 @@
 #define CHANNELCONTROLLER_HPP
 
 #include <map>
+#include <string>
 
 namespace ft {
 
@@ -39,22 +40,16 @@ class ChannelController {
     void updateTopic(Client *client, Channel *channel,
                      const std::string &topic);
 
-    /**
-     * @brief insert Client to Channel's _clientList
-     */
     void insertClient(Channel *channel, Client *client, bool is_operator);
 
-    /**
-     * @brief erase Client to Channel's _clientList
-     */
     void eraseClient(Channel *channel, Client *client);
 
-    /**
-     * @brief Clear Client to _clientList on all channels
-     */
     void eraseClient(Client *client);
 
     bool hasPermission(Channel *channel, Client *client);
+
+    void broadcast(Channel *channel, std::string msg = "",
+                   Client *client = NULL);
 };
 
 }  // namespace ft

--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -2,6 +2,7 @@
 #define CLIENTCONTROLLER_HPP
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 
@@ -15,6 +16,7 @@ class ClientController {
     typedef std::map<int, Client> Clients;
     typedef Clients::iterator client_iterator;
     typedef std::pair<client_iterator, bool> pair;
+    typedef std::set<Client*> ClientList;
 
    private:
     Clients _clients;
@@ -38,16 +40,15 @@ class ClientController {
     void updateNickname(int fd, const std::string& nickname);
     void updateNickname(Client* client, const std::string& nickname);
 
-    /**
-     * @brief insert Channel to Client's _channelList
-     */
     void insertChannel(Client* client, Channel* channel);
     void insertInviteChannel(Client* client, Channel* channel);
 
-    /**
-     * @brief erase Channel to Client's _channelList
-     */
     void eraseChannel(Client* client, Channel* channel);
+
+    void broadcast(Client* client, std::string msg = "");
+
+   private:
+    ClientList findReceivers(Client* client);
 };
 
 }  // namespace ft

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -7,7 +7,7 @@
 
 #include "controller/ChannelController.hpp"
 #include "controller/ClientController.hpp"
-#include "core/Type.hpp"  // ChannelController.hpp 로 이사
+// #include "core/Type.hpp"  // ChannelController.hpp 로 이사
 #include "core/Udata.hpp"
 
 namespace ft {
@@ -35,13 +35,13 @@ class Executor {
     // int joinClient(std::string nickname, std::string channel_name);
 
     void join(int fd, CmdLine cmd_line);
-    void mode(int fd, std::string channel,
+    void mode(int fd, std::string channel_name,
               e_mode mode);  // std::string info
-    void topic(int fd, std::string channel,
+    void topic(int fd, std::string channel_name,
                std::string topic);  // fd -> client ...
-    void invite(int fd, std::string nickname, std::string channel);
+    void invite(int fd, std::string nickname, std::string channel_name);
 
-    void kick(int fd, std::string channel, std::string nickname,
+    void kick(int fd, std::string channel_name, std::string nickname,
               std::string comment);
     void pass(Client *new_client, std::string password,
               std::string server_password);
@@ -55,20 +55,12 @@ class Executor {
     void privmsg(Client *client, CmdLine receivers, std::string msg);
 
    private:
-    // exclude client
     void broadcast(Channel *channel, std::string msg = "",
                    Client *client = NULL);
+    void broadcast(Client *client, std::string msg = "");
+
     ClientList findReceivers(Client *client);
 };
-
-// Executor -> Server data update
-// recv command 수행 PART/QUIT
-
-// join, part, mode, ... cmds
-// switch(cmd)
-// case: join
-// Executor.joinClient()
-
 }  // namespace ft
 
 #endif

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -1,7 +1,6 @@
 #ifndef EXECUTOR_HPP
 #define EXECUTOR_HPP
 
-#include <set>
 #include <string>
 #include <vector>
 
@@ -15,9 +14,9 @@ class Client;
 
 class Executor {
    public:
-    typedef std::vector<std::string> CmdLine;
-    typedef std::vector<std::string>::iterator cmd_iterator;
-    typedef std::set<Client *> ClientList;
+    // typedef std::vector<std::string> std::vector<std::string>;
+    typedef std::vector<std::string>::iterator vector_iterator;
+    // typedef std::set<Client *> ClientList;
 
    private:
     ChannelController channel_controller;
@@ -31,35 +30,23 @@ class Executor {
 
     // method
     Client *creatClient(int fd);
-    void part(int fd, CmdLine channels);
+    void part(Client *client, params *params);
     // int joinClient(std::string nickname, std::string channel_name);
 
-    void join(int fd, CmdLine cmd_line);
-    void mode(int fd, std::string channel_name,
-              e_mode mode);  // std::string info
-    void topic(int fd, std::string channel_name,
-               std::string topic);  // fd -> client ...
-    void invite(int fd, std::string nickname, std::string channel_name);
+    void join(Client *client, params *params);
+    void mode(Client *client, params *params);
+    void topic(Client *client, params *params);
+    void invite(Client *invitor, params *params);
 
-    void kick(int fd, std::string channel_name, std::string nickname,
-              std::string comment);
-    void pass(Client *new_client, std::string password,
-              std::string server_password);
-    void user(Client *new_client, std::string username, std::string hostname,
-              std::string server, std::string realname);
-    void nick(Client *new_client, std::string nickname);
-    void nick(int fd, std::string nickname);
+    void kick(Client *kicker, params *params);
+    void pass(Client *new_client, params *params, std::string server_password);
+    void user(Client *new_client, params *params);
+    void nick(Client *new_client, params *params);
+    void nick(int fd, params *params);
 
-    void quit(int fd, std::string msg);
+    void quit(Client *client, params *params);
 
-    void privmsg(Client *client, CmdLine receivers, std::string msg);
-
-   private:
-    void broadcast(Channel *channel, std::string msg = "",
-                   Client *client = NULL);
-    void broadcast(Client *client, std::string msg = "");
-
-    ClientList findReceivers(Client *client);
+    void privmsg(Client *client, params *params);
 };
 }  // namespace ft
 

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -1,6 +1,7 @@
 #ifndef EXECUTOR_HPP
 #define EXECUTOR_HPP
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -10,11 +11,13 @@
 #include "core/Udata.hpp"
 
 namespace ft {
+class Client;
 
 class Executor {
    public:
     typedef std::vector<std::string> CmdLine;
     typedef std::vector<std::string>::iterator cmd_iterator;
+    typedef std::set<Client *> ClientList;
 
    private:
     ChannelController channel_controller;
@@ -53,7 +56,9 @@ class Executor {
 
    private:
     // exclude client
-    void broadcast(Channel *channel, std::string msg, Client *client = NULL);
+    void broadcast(Channel *channel, std::string msg = "",
+                   Client *client = NULL);
+    ClientList findReceivers(Client *client);
 };
 
 // Executor -> Server data update

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -29,7 +29,6 @@ enum e_cmd {
     TOPIC,
     PRIVMSG,
     NOTICE,
-    // KILL, server operator
     PING,
     PONG
 };

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -110,11 +110,7 @@ void ClientController::updateNickname(int fd, const std::string &nickname) {
 
 void ClientController::updateNickname(Client *client,
                                       const std::string &nickname) {
-    if (find(nickname)) {
-        // no change (already exist)
-    } else {
-        client->setNickname(nickname);
-    }
+    client->setNickname(nickname);
 }
 
 void ClientController::insertChannel(Client *client, Channel *channel) {

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -53,8 +53,6 @@ void Executor::join(int fd, CmdLine cmd_line) {
             }
             client_controller.insertChannel(client, channel);
             broadcast(channel);
-        } else {
-            // invalid channel name
         }
     }
 }

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -120,22 +120,13 @@ void Server::handleConnect(int event_idx) {
     }
     switch (udata->command) {
         case PASS:
-            _executor.pass(new_client,
-                           dynamic_cast<pass_params *>(udata->params)->password,
-                           _env.password);
+            _executor.pass(new_client, udata->params, _env.password);
             break;
         case USER:
-            _executor.user(
-                new_client,
-                dynamic_cast<user_params *>(udata->params)->username,
-                dynamic_cast<user_params *>(udata->params)->hostname,
-                dynamic_cast<user_params *>(udata->params)->servername,
-                dynamic_cast<user_params *>(udata->params)->realname);
+            _executor.user(new_client, udata->params);
             break;
         case NICK:
-            _executor.nick(
-                new_client,
-                dynamic_cast<nick_params *>(udata->params)->nickname);
+            _executor.nick(new_client, udata->params);
             break;
         default:
             // TODO :NAYEON.local 451 * JOIN :You have not registered.
@@ -192,32 +183,31 @@ void Server::handleExecute(int event_idx) {
 
     switch (udata->command) {
         case NICK:
-            _executor.nick(fd, "nickname");  // TODO nickname
+            _executor.nick(fd, udata->params);
             break;
         case JOIN:
-            _executor.join(
-                fd, dynamic_cast<join_params *>(udata->params)->channels);
+            _executor.join(client, udata->params);
             break;
         case PART:
-            _executor.part(
-                fd, dynamic_cast<part_params *>(udata->params)->channels);
+            _executor.part(client, udata->params);
             break;
         case MODE:
-            _executor.mode(fd,
-                           dynamic_cast<mode_params *>(udata->params)->channel,
-                           dynamic_cast<mode_params *>(udata->params)->mode);
+            _executor.mode(client, udata->params);
             break;
         case INVITE:
-            _executor.invite(fd, "nickname", "channel");  // TODO
+            _executor.invite(client, udata->params);
             break;
         case KICK:
-            _executor.kick(fd, "channel", "nickname", "comment");  // TODO
+            _executor.kick(client, udata->params);
             break;
         case PRIVMSG:
-            _executor.privmsg(
-                client,
-                dynamic_cast<privmsg_params *>(udata->params)->receivers,
-                dynamic_cast<privmsg_params *>(udata->params)->msg);
+            _executor.privmsg(client, udata->params);
+            break;
+        case TOPIC:
+            _executor.topic(client, udata->params);
+            break;
+        case QUIT:
+            _executor.quit(client, udata->params);
             break;
             // case NOTICE:
             //      _executor.notice(fd);
@@ -236,8 +226,7 @@ void Server::handleExecute(int event_idx) {
 
 void Server::handleWrite(int event_idx) {
     Event &event = _ev_list[event_idx];
-    std::string &send_buf =
-        static_cast<Udata *>(event.udata)->src->send_buf;
+    std::string &send_buf = static_cast<Udata *>(event.udata)->src->send_buf;
 
     std::cout << "write " << event_idx << std::endl;
     ssize_t n;

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -192,7 +192,7 @@ void Server::handleExecute(int event_idx) {
 
     switch (udata->command) {
         case NICK:
-            _executor.nick(client, "nickname");  // TODO nickname
+            _executor.nick(fd, "nickname");  // TODO nickname
             break;
         case JOIN:
             _executor.join(

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -39,10 +39,6 @@ void Channel::setMode(int mode) {
 
 // update
 void Channel::insertClient(Client *client, bool is_operator) {
-    // if (isOperator(client)) {
-    //     _operators.insert(client);
-    // } else {
-    // }
     if (is_operator)
         _operators.insert(client);
     else
@@ -61,13 +57,13 @@ bool Channel::isInviteMode() { return (_mode & (INVITE_ONLY_T - 1)); }
 bool Channel::isTopicMode() { return (_mode & (TOPIC_PRIV_T - 1)); }
 bool Channel::isBanMode() { return (_mode & (BAN_T - 1)); }
 
-bool Channel::isOnChannel(Client *client){
+bool Channel::isOnChannel(Client *client) {
     return (isOperator(client) || isRegular(client));
 }
-bool Channel::isOperator(Client *client){
+bool Channel::isOperator(Client *client) {
     return _operators.find(client) != _operators.end() ? true : false;
 }
-bool Channel::isRegular(Client *client){
+bool Channel::isRegular(Client *client) {
     return _regulars.find(client) != _regulars.end() ? true : false;
 }
 

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -60,7 +60,7 @@ void EventHandler::handleEvent(int event_idx) {
             handleTimeout(event_idx);
             break;
         case CLOSE:
-            //handleClose(event_idx); // TODO
+            // handleClose(event_idx); // TODO
             break;
         default:
             std::cout << "client #" << _ev_list[event_idx].ident


### PR DESCRIPTION
## 개요
- executor 멤버 함수에 broadcast 추가

## 작업내용
- 여러 채널에 broadcast하는 함수 오버라이딩
- 각 executor의 함수에 broadcast 사용
- std::string channel 파라미터 -> std::string channel_name으로 리팩토링 (channel은 Channel * 타입인 경우)
- executor::* 함수들 프로토타입 수정 `(Client *client, params *params)`
- broadcast 함수 Executor에서 ClientController, ChannelController 멤버 함수로 이동

## 주의사항
- channel name에 '#' 붙지 않은 경우 parse에서 invalid channel name 추가 필요
- Channel::ClientList, Client::ChannelList 사용 유무 고민해보기