### PR TITLE
[Refactor] Executor connect, execute 함수 추가

### DIFF
--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -13,11 +13,6 @@ namespace ft {
 class Client;
 
 class Executor {
-   public:
-    // typedef std::vector<std::string> std::vector<std::string>;
-    typedef std::vector<std::string>::iterator vector_iterator;
-    // typedef std::set<Client *> ClientList;
-
    private:
     ChannelController channel_controller;
     ClientController client_controller;
@@ -28,24 +23,22 @@ class Executor {
     ~Executor();
     Executor &operator=(const Executor &ref);
 
-    // method
+    void connect(Command *command, Client *client, std::string password);
+    void execute(Command *command, Client *client);
     Client *creatClient(int fd);
-    void part(Client *client, params *params);
-    // int joinClient(std::string nickname, std::string channel_name);
 
+   private:
+    void pass(Client *new_client, params *params, std::string server_password);
+    void user(Client *new_client, params *params);
+    void nick(Client *new_client, params *params);
+    void part(Client *client, params *params);
     void join(Client *client, params *params);
     void mode(Client *client, params *params);
     void topic(Client *client, params *params);
     void invite(Client *invitor, params *params);
-
     void kick(Client *kicker, params *params);
-    void pass(Client *new_client, params *params, std::string server_password);
-    void user(Client *new_client, params *params);
-    void nick(Client *new_client, params *params);
     void nick(int fd, params *params);
-
     void quit(Client *client, params *params);
-
     void privmsg(Client *client, params *params);
 };
 }  // namespace ft

--- a/include/core/Udata.hpp
+++ b/include/core/Udata.hpp
@@ -66,17 +66,14 @@ struct ping_params : public params {
 };
 
 struct Command {
-    e_cmd command;
+    e_cmd type;
     params *params;
 };
 
 struct Udata {
     e_event action;
     int status;
-    std::string msg;
-    e_cmd command;
-    params *params;
-//    std::vector<Command> commands;
+    std::vector<Command> commands;
     Client *src;
 
     Udata();

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -14,6 +14,66 @@ Executor::~Executor() {}
 
 Executor &Executor::operator=(const Executor &ref) { return (*this); }
 
+void Executor::connect(Command *command, Client *client, std::string password) {
+    switch (command->type) {
+        case PASS:
+            pass(client, command->params, password);
+            break;
+        case USER:
+            user(client, command->params);
+            break;
+        case NICK:
+            nick(client, command->params);
+            break;
+        default:
+            // TODO :NAYEON.local 451 * JOIN :You have not registered.
+            break;
+    }
+}
+
+void Executor::execute(Command *command, Client *client) {
+    switch (command->type) {
+        case NICK:
+            nick(client->getFd(), command->params);
+            break;
+        case JOIN:
+            join(client, command->params);
+            break;
+        case PART:
+            part(client, command->params);
+            break;
+        case MODE:
+            mode(client, command->params);
+            break;
+        case INVITE:
+            invite(client, command->params);
+            break;
+        case KICK:
+            kick(client, command->params);
+            break;
+        case PRIVMSG:
+            privmsg(client, command->params);
+            break;
+        case TOPIC:
+            topic(client, command->params);
+            break;
+        case QUIT:
+            quit(client, command->params);
+            break;
+            // case NOTICE:
+            //      notice(fd);
+            //     break;
+            // case PING:
+            //      ping(fd);
+            //     break;
+            // case PONG:
+            //      pong(fd);
+            //     break;
+        default:
+            break;
+    }
+}
+
 Client *Executor::creatClient(int fd) { return client_controller.insert(fd); }
 
 /**

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -25,7 +25,7 @@ void Env::parse(int argc, char **argv) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     d_port = std::strtod(port_str.c_str(), &back);
-    if (*back || d_port < 1025 | d_port > 65535) {
+    if (*back || d_port<1025 | d_port> 65535) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     }
@@ -95,8 +95,8 @@ void Server::handleConnect(int event_idx) {
     char buf[BUF_SIZE];
     ssize_t n = 0;
     Event event = _ev_list[event_idx];
-    Client *new_client = ((Udata *) event.udata)->src;
     Udata *udata = static_cast<Udata *>(event.udata);
+    Client *new_client = udata->src;
 
     n = recv(event.ident, &buf, BUF_SIZE, 0);
     buf[n] = 0;
@@ -106,8 +106,8 @@ void Server::handleConnect(int event_idx) {
     pos = new_client->recv_buf.find('\n');
     if (pos != std::string::npos) {
         command_line = new_client->recv_buf.substr(0, pos);
-        _parser.parse(command_line, ((Udata *) udata)->command,
-                      ((Udata *) udata)->params);
+        // _parser.parse(command_line, ((Udata *)udata)->command,
+        //               ((Udata *)udata)->params);
         new_client->recv_buf =
             new_client->recv_buf.substr(pos + 1, new_client->recv_buf.length());
     }
@@ -117,25 +117,18 @@ void Server::handleConnect(int event_idx) {
         std::cout << "\tcommand_line: " << command_line << std::endl;
         std::cout << "\trecv_buf: " << new_client->recv_buf << std::endl;
     }
-    switch (udata->command) {
-        case PASS:
-            _executor.pass(new_client, udata->params, _env.password);
-            break;
-        case USER:
-            _executor.user(new_client, udata->params);
-            break;
-        case NICK:
-            _executor.nick(new_client, udata->params);
-            break;
-        default:
-            // TODO :NAYEON.local 451 * JOIN :You have not registered.
-            break;
+
+    std::vector<Command>::iterator iter = udata->commands.begin();
+    for (; iter != udata->commands.end(); ++iter) {
+        _executor.connect(&*iter, new_client, _env.password);
     }
+
     if (new_client->isAuthenticate()) {
         send(event.ident, WELCOME_PROMPT, strlen(WELCOME_PROMPT), 0);
 
-        registerEvent(event.ident, READ, (Udata *) event.udata);
-        registerEvent(event.ident, DEL_WRITE, static_cast<Udata *>(event.udata));
+        registerEvent(event.ident, READ, (Udata *)event.udata);
+        registerEvent(event.ident, DEL_WRITE,
+                      static_cast<Udata *>(event.udata));
         std::cout << "#" << event.ident << "READ event registered!"
                   << std::endl;
     }
@@ -147,8 +140,8 @@ void Server::handleRead(int event_idx) {
     char buf[BUF_SIZE];
     Event event = _ev_list[event_idx];
     ssize_t n = 0;
-
-    ConnectSocket *sock = ((Udata *) event.udata)->src;
+    Udata *udata = static_cast<Udata *>(event.udata);
+    ConnectSocket *sock = udata->src;
 
     n = recv(event.ident, &buf, BUF_SIZE, 0);
     buf[n] = 0;
@@ -163,8 +156,8 @@ void Server::handleRead(int event_idx) {
 
     if (pos != std::string::npos) {
         command_line = str_buf.substr(0, pos);
-        _parser.parse(command_line, ((Udata *) event.udata)->command,
-                      ((Udata *) event.udata)->params);
+        // _parser.parse(command_line, ((Udata *)event.udata)->command,
+        //               ((Udata *)event.udata)->params);
 
         sock->recv_buf = str_buf.substr(pos + 1, str_buf.length());
 
@@ -182,46 +175,11 @@ void Server::handleExecute(int event_idx) {
     int numeric_replie;
     int fd = _ev_list[event_idx].ident;
 
-    switch (udata->command) {
-        case NICK:
-            _executor.nick(fd, udata->params);
-            break;
-        case JOIN:
-            _executor.join(client, udata->params);
-            break;
-        case PART:
-            _executor.part(client, udata->params);
-            break;
-        case MODE:
-            _executor.mode(client, udata->params);
-            break;
-        case INVITE:
-            _executor.invite(client, udata->params);
-            break;
-        case KICK:
-            _executor.kick(client, udata->params);
-            break;
-        case PRIVMSG:
-            _executor.privmsg(client, udata->params);
-            break;
-        case TOPIC:
-            _executor.topic(client, udata->params);
-            break;
-        case QUIT:
-            _executor.quit(client, udata->params);
-            break;
-            // case NOTICE:
-            //      _executor.notice(fd);
-            //     break;
-            // case PING:
-            //      _executor.ping(fd);
-            //     break;
-            // case PONG:
-            //      _executor.pong(fd);
-            //     break;
-        default:
-            break;
+    std::vector<Command>::iterator iter = udata->commands.begin();
+    for (; iter != udata->commands.end(); ++iter) {
+        _executor.execute(&*iter, client);
     }
+
     registerEvent(_ev_list[event_idx].ident, WRITE, udata);
 }
 

--- a/src/core/Udata.cpp
+++ b/src/core/Udata.cpp
@@ -2,16 +2,14 @@
 
 namespace ft {
 
-Udata::Udata() : action(IDLE), status(0), params(NULL), src(NULL) {}
+Udata::Udata() : action(IDLE), status(0), src(NULL) {}
 Udata::Udata(const Udata &copy) { *this = copy; }
 Udata::~Udata() {}
 
 Udata &Udata::operator=(const Udata &ref) {
     action = ref.action;
     status = ref.status;
-    command = ref.command;
-    params = ref.params;
-    msg = ref.msg;
+    commands = ref.commands;
     src = ref.src;
 
     return (*this);


### PR DESCRIPTION
## 개요
- `Server::handleExecute`, `Server::handleConnect` 분기 -> `Executor::execute`, `Executor::connect` 분기 처리로 수정

## 작업내용
- `Executor::execute`, `Executor::connect`를 Executor public 함수로 추가
- Executor 나머지 함수를 public에서 private로 수정
- Udata에 `vector<Command> commands` 추가 (struct Commands에 type, params 존재)

## 주의사항
- handleConnect, handleRead에 `_parser.parse()` 호출 부분 수정 필요 (주석 처리 해둠)