### PR TITLE
[Feature] Add EventHandler::garbageCollector

### DIFF
--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -27,6 +27,9 @@ class Executor {
     void execute(Command *command, Client *client);
     Client *createClient(int fd);
     Channel *createChannel(std::string channel_name);
+    void deleteClient(Client *client);
+
+    bool isConnected(Client *client);
 
    private:
     void pass(Client *new_client, params *params, std::string server_password);

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -6,10 +6,11 @@
 
 #include "Parser.hpp"
 #include "controller/Executor.hpp"
-#include "handler/EventHandler.hpp"
 #include "core/Socket.hpp"
+#include "handler/EventHandler.hpp"
 
-#define WELCOME_PROMPT "\n\
+#define WELCOME_PROMPT \
+    "\n\
 \n\
 ███████╗██╗   ██╗███████╗██████╗ ███████╗███████╗███████╗\n\
 ██╔════╝╚██╗ ██╔╝██╔════╝██╔══██╗██╔════╝██╔════╝██╔════╝\n\
@@ -54,7 +55,12 @@ class Server : public EventHandler {
     void handleRead(int event_idx);
     void handleExecute(int event_idx);
     void handleWrite(int event_idx);
-    void handleTimeout(int event_idx);
+
+    // garbageCollector methods
+    void handleTimeout();
+    void handleClose();
+
+    bool isConnected(Udata *udata);
 };
 
 }  // namespace ft

--- a/include/core/Socket.hpp
+++ b/include/core/Socket.hpp
@@ -50,6 +50,7 @@ class ConnectSocket : public SocketBase {
     ConnectSocket &operator=(const ConnectSocket &ref);
 
     bool isAuthenticate();
+    // TODO : bool isConnected();
     void createSocket(const int &listen_fd);
     std::string readRecvBuf();
 };

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -9,10 +9,8 @@ enum e_event {
     READ_MORE,
     WRITE,
     EXCUTE,
-    CLOSE,
     DEL_READ,
     DEL_WRITE,
-    TIMEOUT,
     IDLE
 };
 
@@ -30,7 +28,8 @@ enum e_cmd {
     PRIVMSG,
     NOTICE,
     PING,
-    PONG
+    PONG,
+    UNKNOWN
 };
 
 enum e_mode {

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -9,8 +9,8 @@ enum e_event {
     READ_MORE,
     WRITE,
     EXCUTE,
-    DEL_READ,
-    DEL_WRITE,
+    D_READ,
+    D_WRITE,
     IDLE
 };
 

--- a/include/core/Udata.hpp
+++ b/include/core/Udata.hpp
@@ -68,6 +68,9 @@ struct ping_params : public params {
 struct Command {
     e_cmd type;
     params *params;
+
+    Command();
+    ~Command();
 };
 
 struct Udata {

--- a/include/handler/EventHandler.hpp
+++ b/include/handler/EventHandler.hpp
@@ -47,6 +47,7 @@ class EventHandler {
     virtual void handleExecute(int event_idx) = 0;
     virtual void handleWrite(int event_idx) = 0;
 
+    // TODO : checkConnection in handleConnect, handleREAD
     virtual bool isConnected(Udata *udata) = 0;
 };
 }  // namespace ft

--- a/include/handler/EventHandler.hpp
+++ b/include/handler/EventHandler.hpp
@@ -3,6 +3,7 @@
 
 #include <sys/event.h>
 
+#include <set>
 #include <vector>
 
 #include "core/Udata.hpp"
@@ -19,6 +20,9 @@ class EventHandler {
     int _kq_fd;
     int _change_cnt;
 
+    std::set<Udata *> _unregisters;  // timeout
+    std::set<Udata *> _garbage;      // client gone
+
     Event _ev_list[_max_event];
     EventList _change_list;
 
@@ -31,6 +35,10 @@ class EventHandler {
 
     int monitorEvent();
 
+    void garbageCollector();           // TODO : naming;
+    virtual void handleTimeout() = 0;  // TODO : naming;
+    virtual void handleClose() = 0;    // TODO : naming;
+
     // handle functions
     void handleEvent(int event_idx);
     virtual void handleAccept() = 0;
@@ -38,7 +46,8 @@ class EventHandler {
     virtual void handleRead(int event_idx) = 0;
     virtual void handleExecute(int event_idx) = 0;
     virtual void handleWrite(int event_idx) = 0;
-    virtual void handleTimeout(int event_idx) = 0;
+
+    virtual bool isConnected(Udata *udata) = 0;
 };
 }  // namespace ft
 

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -1,7 +1,7 @@
 #include "controller/Executor.hpp"
 
-#include <utility>
 #include <iostream>
+#include <utility>
 
 #include "entity/Channel.hpp"
 #include "entity/Client.hpp"
@@ -16,7 +16,9 @@ Executor::~Executor() {}
 Executor &Executor::operator=(const Executor &ref) { return (*this); }
 
 Client *Executor::createClient(int fd) { return client_controller.insert(fd); }
-
+Channel *Executor::createChannel(std::string channel_name) {
+    return channel_controller.insert(channel_name);
+}
 void Executor::deleteClient(Client *client) {
     channel_controller.eraseClient(client);
     client_controller.erase(client->getFd());
@@ -39,7 +41,8 @@ void Executor::connect(Command *command, Client *client, std::string password) {
             nick(client, command->params);
             break;
         default:
-            std::cout << ":NAYEON.local 451 * JOIN :You have not registered." << std::endl;
+            std::cout << ":NAYEON.local 451 * JOIN :You have not registered."
+                      << std::endl;
             break;
     }
 }
@@ -87,9 +90,6 @@ void Executor::execute(Command *command, Client *client) {
     }
 }
 
-Client *Executor::createClient(int fd) { return client_controller.insert(fd); }
-Channel *Executor::createChannel(std::string channel_name) { return channel_controller.insert(channel_name); }
-
 /**
  * @brief part channels
  *
@@ -123,7 +123,7 @@ void Executor::join(Client *client, params *params) {
             Channel *channel = channel_controller.find(*iter);
             if (channel == NULL) {  // new channel
                 channel = channel_controller.insert(*iter);
-//                channel_controller.insert(*iter);
+                //                channel_controller.insert(*iter);
                 channel_controller.insertClient(channel, client, true);
             } else {
                 channel_controller.insertClient(channel, client, false);

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -15,6 +15,18 @@ Executor::~Executor() {}
 
 Executor &Executor::operator=(const Executor &ref) { return (*this); }
 
+Client *Executor::createClient(int fd) { return client_controller.insert(fd); }
+
+void Executor::deleteClient(Client *client) {
+    channel_controller.eraseClient(client);
+    client_controller.erase(client->getFd());
+}
+
+bool Executor::isConnected(Client *client) {
+    // TODO : SIGINT(CTRL-C)
+    return client && client->recv_buf.length();
+}
+
 void Executor::connect(Command *command, Client *client, std::string password) {
     switch (command->type) {
         case PASS:

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -110,7 +110,7 @@ void Server::handleConnect(int event_idx) {
     std::vector<std::string> command_lines = split(line, '\n');
     std::vector<std::string>::iterator it;
     for (it = command_lines.begin(); it != command_lines.end(); it++) {
-        Command command = {};
+        Command command;
 
         _parser.parse(*it, command.type, command.params);
         udata->commands.push_back(command);
@@ -154,7 +154,7 @@ void Server::handleRead(int event_idx) {
     std::vector<std::string> command_lines = split(line, '\n');
     std::vector<std::string>::iterator it;
     for (it = command_lines.begin(); it != command_lines.end(); it++) {
-        Command command = {};
+        Command command;
 
         _parser.parse(*it, command.type, command.params);
         udata->commands.push_back(command);
@@ -188,7 +188,7 @@ void Server::handleWrite(int event_idx) {
     ssize_t n;
     n = send(event.ident, send_buf.c_str(), send_buf.length(), 0);
     if (n == send_buf.length())
-        registerEvent(event.ident, DEL_WRITE, NULL);
+        registerEvent(event.ident, D_WRITE, NULL);
     else if (n == -1) {
         std::cerr << "[UB] send return -1" << std::endl;
     } else {

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -65,6 +65,7 @@ void Server::run() {
         for (int i = 0; i < n; i++) {
             handleEvent(i);
         }
+        garbageCollector();
     }
 }
 
@@ -86,7 +87,7 @@ void Server::handleAccept() {
     data->src = new_client;
 
     registerEvent(new_client->getFd(), CONNECT, data);
-    // registerEvent(new_client->getFd(), TIMEOUT, data); // TODO
+    _unregisters.insert(data);
 }
 
 void Server::handleConnect(int event_idx) {
@@ -126,10 +127,10 @@ void Server::handleConnect(int event_idx) {
     // check is authenticate
     if (new_client->isAuthenticate()) {
         send(event.ident, WELCOME_PROMPT, strlen(WELCOME_PROMPT), 0);
-
-        registerEvent(event.ident, READ, (Udata *) event.udata);
-//        registerEvent(event.ident, DEL_WRITE,
-//                      static_cast<Udata *>(event.udata));
+        _unregisters.erase(udata);
+        registerEvent(event.ident, READ, udata);
+        std::cout << "#" << event.ident << "READ event registered!"
+                  << std::endl;
     }
 }
 
@@ -195,16 +196,40 @@ void Server::handleWrite(int event_idx) {
     }
 }
 
-void Server::handleTimeout(int event_idx) {
-    long long start =
-        static_cast<Udata *>(_ev_list[event_idx].udata)->src->create_time;
-    // registerEvent(_ev_list[event_idx].ident, DEL_WRITE, 0);  //
-    // 나중에고치기
+void Server::handleTimeout() {
+    std::vector<Udata *> tmp; // iterator 생명주기..
+    std::set<Udata *>::iterator iter = _unregisters.begin();
 
-    if (getTicks() > start + 10000) {
-        registerEvent(_ev_list[event_idx].ident, DEL_READ, 0);
-        registerEvent(_ev_list[event_idx].ident, CLOSE, 0);
+    tmp.reserve(_unregisters.size());
+    for (; iter != _unregisters.end(); ++iter) {
+        if (getTicks() > (*iter)->src->create_time + 15000) {
+            _garbage.insert(*iter);
+            tmp.push_back(*iter);
+            // std::cout << "New client # " << (*iter)->src->getFd()
+            //           << " timeout for register" << std::endl;
+        }
     }
+    if (tmp.size()) {
+        std::vector<Udata *>::iterator tmp_iter = tmp.begin();
+        for (; tmp_iter != tmp.end(); ++tmp_iter) {
+            _unregisters.erase(*tmp_iter);
+        }
+    }
+}
+
+void Server::handleClose() {
+    std::set<Udata *>::iterator iter = _garbage.begin();
+    for (; iter != _garbage.end(); ++iter) {
+        std::cout << "New client # " << (*iter)->src->getFd() << " gone"
+                  << std::endl;
+        _executor.deleteClient((*iter)->src);
+        delete (*iter);
+    }
+    _garbage.clear();
+}
+
+bool Server::isConnected(Udata *udata) {
+    return _executor.isConnected(udata->src);
 }
 
 const char *Parser::SyntaxException::what() const throw() {

--- a/src/core/Udata.cpp
+++ b/src/core/Udata.cpp
@@ -2,6 +2,11 @@
 
 namespace ft {
 
+Command::Command() : type(UNKNOWN), params(NULL){};
+Command::~Command() {
+    if (params) delete params;
+};
+
 Udata::Udata() : action(IDLE), status(0), src(NULL) {}
 Udata::Udata(const Udata &copy) { *this = copy; }
 Udata::~Udata() {}

--- a/src/entity/Client.cpp
+++ b/src/entity/Client.cpp
@@ -7,7 +7,7 @@ Client::Client(const std::string &nickname) : _nickname(nickname) {}
 
 Client::Client(const Client &copy) { *this = copy; }
 
-Client::~Client() {}
+Client::~Client() { deleteSocket(); }
 
 Client &Client::operator=(const Client &ref) { return (*this); }
 

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -22,7 +22,7 @@ EventHandler::~EventHandler() {}
 
 int EventHandler::monitorEvent() {
     int n = kevent(_kq_fd, &_change_list[0], _change_cnt, _ev_list, _max_event,
-                   NULL); // TODO : TIMEOUT
+                   NULL);  // TODO : TIMEOUT
 
     _change_list.clear();
     _change_cnt = 0;
@@ -79,6 +79,7 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
     Event ev = {};
 
     // TODO 이것도 모든 경우에 다 맞는지 생각해 주어야 함
+    // ACCEPT/CONNECT/READ 따로 EXCUTE/WRITE 따로
     if (udata) udata->action = action;
     switch (action) {
         case ACCEPT:
@@ -99,11 +100,11 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
             EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
                    static_cast<void *>(udata));
             break;
-        case DEL_READ:
-            EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
+        case D_READ:
+            EV_SET(&ev, fd, EVFILT_READ, EV_DISABLE, 0, 0, 0);
             break;
-        case DEL_WRITE:
-            EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
+        case D_WRITE:
+            EV_SET(&ev, fd, EVFILT_WRITE, EV_DISABLE, 0, 0, 0);
             break;
         default:
             return;


### PR DESCRIPTION
## 개요
목적 : close(fd), delete udata 처리
- EventHandler 에 garbageCollector 추가
  - feat1 : 제한 시간(현재 15초)내에 register 하지 못한 Client 연결 끊기
  - feat2 :  연결이 끊긴 Client 삭제
- 변경사항 handleTimeout, handleClose 
  - 기존 : handleEvent 에서 사용
  - 현재 : garbageCollector 에서 사용
## 작업내용
- close connected_fd : Client::~Client()
- delete client(stl) : Executor::deleteClient()
  - ChannelController::eraseClient(client)
  - ClientController::erase(client->getFd())
- delete param : Command::~Command()
- delete udata : Server::handleClose()
## 주의사항
- [중요!!!] iterator 로 순회하다가 해당 노드/위치를 delete 해버리면, 해당 순회는 유효하지 않음 
  - stl 을 사용한 erase 중에 already freed memory에 접근 한다면 의심해보기
- renaming 필요
- monitorEvent에서 kevent 사용시 Timer(마지막 인자)설정 해줘야 Timeout 제대로 동작
- ErrorHandler 오늘 열심히 해볼게요.. 죄송합니닷...
- 변경사항에 대한 이유 : close(fd) 했을 때, kqueue는 소켓이 닫혔음을 내부적으로 자동으로 발견 가능
  - 즉, close 전에, 관련 이벤트를 kqueue에서 수동 삭제할 필요 없음
- EV_DELETE 잘못 알고 쓰고 있었음
  - kqueue에서 이벤트 제거하는건 맞음
  - fd의 경우 디스크립터가 close 될때임

---

- [ ] EV_DELETE 제대로 쓰기
  - WRITE 완료면 EV_DISABLE 해줘서 이벤트 감지 못하게 하기!