### PR TITLE
[Fix] Hotfix/executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ fclean: clean
 re: fclean all
 
 .PHONY	: debug
-debug	:
+debug	: fclean
 	@make DEBUG=1 all
 
 .PHONY	: leaks

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -2,17 +2,9 @@
 #define TYPE_HPP
 
 namespace ft {
-enum e_event {
-    ACCEPT,
-    CONNECT,
-    READ,
-    READ_MORE,
-    WRITE,
-    EXCUTE,
-    D_READ,
-    D_WRITE,
-    IDLE
-};
+enum e_event { ACCEPT, CONNECT, READ, EXECUTE, WRITE, D_READ, D_WRITE, IDLE };
+
+enum e_filt { FILT_READ, FILT_WRITE };
 
 enum e_cmd {
     PASS,

--- a/include/core/Udata.hpp
+++ b/include/core/Udata.hpp
@@ -76,7 +76,7 @@ struct Command {
 struct Udata {
     e_event action;
     int status;
-    std::vector<Command> commands;
+    std::vector<Command *> commands;
     Client *src;
 
     Udata();

--- a/include/core/Udata.hpp
+++ b/include/core/Udata.hpp
@@ -74,7 +74,8 @@ struct Command {
 };
 
 struct Udata {
-    e_event action;
+    e_event r_action;
+    e_event w_action;
     int status;
     std::vector<Command *> commands;
     Client *src;

--- a/include/handler/EventHandler.hpp
+++ b/include/handler/EventHandler.hpp
@@ -31,7 +31,7 @@ class EventHandler {
     EventHandler(const EventHandler &copy);
     virtual ~EventHandler();
 
-    void registerEvent(int fd, e_event action, Udata *udata);
+    void registerEvent(int fd, e_filt filt, e_event action, Udata *udata);
 
     int monitorEvent();
 

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -125,12 +125,14 @@ void ChannelController::broadcast(Channel *channel, std::string msg,
     for (; iter != operators.end(); ++iter) {
         if (client == NULL || client->getFd() != (*iter)->getFd())
             //	client -> send queue -> push_back
-            send((*iter)->getFd(), msg.c_str(), msg.length(), 0);
+            // send((*iter)->getFd(), msg.c_str(), msg.length(), 0);
+            client->send_buf.append("msg : " + msg);
     }
     iter = regulars.begin();
     for (; iter != regulars.end(); ++iter) {
         if (client == NULL || client->getFd() != (*iter)->getFd())
-            send((*iter)->getFd(), msg.c_str(), msg.length(), 0);
+            // send((*iter)->getFd(), msg.c_str(), msg.length(), 0);
+            client->send_buf.append("msg : " + msg);
     }
 }
 Channel *ChannelController::insert(std::string &channel_name) {

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -123,16 +123,15 @@ void ChannelController::broadcast(Channel *channel, std::string msg,
     Channel::client_list_iterator iter = operators.begin();
 
     for (; iter != operators.end(); ++iter) {
-        if (client == NULL || client->getFd() != (*iter)->getFd())
-            //	client -> send queue -> push_back
-            // send((*iter)->getFd(), msg.c_str(), msg.length(), 0);
-            client->send_buf.append("msg : " + msg);
+        (*iter)->send_buf.append(msg + "\n");
+        // if (client != NULL && client != *iter) {
+        // }
     }
     iter = regulars.begin();
     for (; iter != regulars.end(); ++iter) {
-        if (client == NULL || client->getFd() != (*iter)->getFd())
-            // send((*iter)->getFd(), msg.c_str(), msg.length(), 0);
-            client->send_buf.append("msg : " + msg);
+        (*iter)->send_buf.append(msg + "\n");
+        // if (client != NULL && client != *iter) {
+        // }
     }
 }
 Channel *ChannelController::insert(std::string &channel_name) {

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -142,7 +142,8 @@ void ClientController::broadcast(Client *client, std::string msg) {
     for (; client_iter != receivers.end(); ++client_iter) {
         // push send_queue
         // (*client_iter)->insertSendQueue(respons);
-        send((*client_iter)->getFd(), msg.c_str(), msg.length(), 0);
+        // send((*client_iter)->getFd(), msg.c_str(), msg.length(), 0);
+        client->send_buf.append("msg : " + msg);
     }
 }
 

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -90,6 +90,11 @@ void Executor::execute(Command *command, Client *client) {
     }
 }
 
+Client *Executor::createClient(int fd) { return client_controller.insert(fd); }
+Channel *Executor::createChannel(std::string channel_name) {
+    return channel_controller.insert(channel_name);
+}
+
 /**
  * @brief part channels
  *
@@ -297,8 +302,9 @@ void Executor::privmsg(Client *client, params *params) {
             name = *iter;
             Client *receiver = client_controller.find(name);
             if (receiver) {
-                send(client_controller.find(name)->getFd(), msg.c_str(),
-                     msg.length(), 0);
+                receiver->send_buf.append("privmsg : " + msg);
+                // send(client_controller.find(name)->getFd(), msg.c_str(),
+                //      msg.length(), 0);
             } else {
                 // 401 user3 wow :No such nick
             }

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -25,7 +25,7 @@ void Env::parse(int argc, char **argv) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     d_port = std::strtod(port_str.c_str(), &back);
-    if (*back || d_port < 1025 | d_port > 65535) {
+    if (*back || d_port<1025 | d_port> 65535) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     }
@@ -161,8 +161,7 @@ void Server::handleRead(int event_idx) {
     }
 
     // registerRead
-    if (command_lines.size())
-        registerEvent(event.ident, EXCUTE, udata);
+    if (command_lines.size()) registerEvent(event.ident, EXCUTE, udata);
 }
 
 void Server::handleExecute(int event_idx) {
@@ -197,7 +196,7 @@ void Server::handleWrite(int event_idx) {
 }
 
 void Server::handleTimeout() {
-    std::vector<Udata *> tmp; // iterator 생명주기..
+    std::vector<Udata *> tmp;  // iterator 생명주기..
     std::set<Udata *>::iterator iter = _unregisters.begin();
 
     tmp.reserve(_unregisters.size());

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -188,7 +188,7 @@ void Server::handleWrite(int event_idx) {
 
     std::string &send_buf = static_cast<Udata *>(event.udata)->src->send_buf;
 
-//    std::cout << "write " << event_idx << std::endl;
+    std::cout << "write " << event_idx << std::endl;
     ssize_t n;
     n = send(event.ident, send_buf.c_str(), send_buf.length(), 0);
     if (n == send_buf.length()) {
@@ -198,6 +198,7 @@ void Server::handleWrite(int event_idx) {
         std::cerr << "[UB] send return -1" << std::endl;
     } else {
         send_buf = send_buf.substr(n, send_buf.length());
+        registerEvent(event.ident, WRITE, udata);
     }
 }
 

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -56,7 +56,9 @@ void Server::run() {
     std::cout << "🚀 Server running listening on port " << _env.port
               << std::endl;
     // TODO : [naming] 실제로 register 되는 시점은 여기가 아님.
-    registerEvent(_listen_socket.getFd(), ACCEPT, 0);
+    Udata *udata = new Udata;
+    udata->action = ACCEPT;
+    registerEvent(_listen_socket.getFd(), ACCEPT, udata);
     //_change_list.clear();
     //_change_cnt = 0;
     // 2. update (server socket)

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -25,7 +25,7 @@ void Env::parse(int argc, char **argv) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     d_port = std::strtod(port_str.c_str(), &back);
-    if (*back || d_port<1025 | d_port> 65535) {
+    if (*back || d_port < 1025 | d_port > 65535) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     }
@@ -185,17 +185,15 @@ void Server::handleWrite(int event_idx) {
     Event &event = _ev_list[event_idx];
     // tmp
     Udata *udata = static_cast<Udata *>(event.udata);
-    // std::cout << "udata->src->send_buf : " << udata->src->send_buf <<
-    // std::endl;
 
     std::string &send_buf = static_cast<Udata *>(event.udata)->src->send_buf;
 
-    std::cout << "write " << event_idx << std::endl;
+//    std::cout << "write " << event_idx << std::endl;
     ssize_t n;
     n = send(event.ident, send_buf.c_str(), send_buf.length(), 0);
     if (n == send_buf.length()) {
-        registerEvent(event.ident, D_WRITE, NULL);
         send_buf.clear();
+        registerEvent(event.ident, READ, udata);
     } else if (n == -1) {
         std::cerr << "[UB] send return -1" << std::endl;
     } else {

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -29,6 +29,7 @@ SocketBase &SocketBase::operator=(const SocketBase &ref) {
 const int SocketBase::getFd() const { return _fd; }
 
 void SocketBase::deleteSocket() {
+    // std::cout << "delet?";
     if (_fd != -1) close(_fd);
 }
 void SocketBase::setFd(int fd) { _fd = fd; }
@@ -54,7 +55,7 @@ void ListenSocket::createSocket(const int &port) {
     sin.sin_port = htons(port);
     int i = 0;
     // 임시
-    while (bind(_fd, (struct sockaddr *) &sin, sizeof(sin)) < 0) {
+    while (bind(_fd, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
         sin.sin_port = htons(port + ++i);
     }
     std::cout << "listening port : " << port + i << std::endl;
@@ -88,7 +89,7 @@ void ConnectSocket::createSocket(const int &listen_fd) {
     struct sockaddr_in in = {};
     socklen_t in_len = sizeof(in);
 
-    _fd = accept(listen_fd, (struct sockaddr *) &in, &in_len);
+    _fd = accept(listen_fd, (struct sockaddr *)&in, &in_len);
     setNonBlock();
     // TODO : password
     // recv(connect_fd, buf, 0, 0); // TODO : why warning in irssi (CR/LF)

--- a/src/core/Udata.cpp
+++ b/src/core/Udata.cpp
@@ -4,7 +4,9 @@ namespace ft {
 
 Command::Command() : type(UNKNOWN), params(NULL){};
 Command::~Command() {
-    if (params) delete params;
+    if (params) {
+        delete params;
+    }
 };
 
 Udata::Udata() : action(IDLE), status(0), src(NULL) {}

--- a/src/core/Udata.cpp
+++ b/src/core/Udata.cpp
@@ -9,12 +9,11 @@ Command::~Command() {
     }
 };
 
-Udata::Udata() : action(IDLE), status(0), src(NULL) {}
+Udata::Udata() : r_action(IDLE), w_action(IDLE), status(0), src(NULL) {}
 Udata::Udata(const Udata &copy) { *this = copy; }
 Udata::~Udata() {}
 
 Udata &Udata::operator=(const Udata &ref) {
-    action = ref.action;
     status = ref.status;
     commands = ref.commands;
     src = ref.src;

--- a/src/entity/Client.cpp
+++ b/src/entity/Client.cpp
@@ -7,7 +7,9 @@ Client::Client(const std::string &nickname) : _nickname(nickname) {}
 
 Client::Client(const Client &copy) { *this = copy; }
 
-Client::~Client() { deleteSocket(); }
+Client::~Client() {
+    // deleteSocket();
+}
 
 Client &Client::operator=(const Client &ref) { return (*this); }
 

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -45,7 +45,7 @@ void EventHandler::handleEvent(int event_idx) {
     e_event action = udata ? udata->r_action : ACCEPT;
     if (event.filter == EVFILT_WRITE) action = udata->w_action;
 
-    if ((event.fflags & EV_EOF) && udata && !isConnected(udata)) {
+    if ((event.flags & EV_EOF) && udata && !isConnected(udata)) {
         // TODO : ctrl-D 처리
         _unregisters.erase(udata);
         _garbage.insert(udata);

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -94,17 +94,18 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
                    static_cast<void *>(udata));
             break;
         case EXCUTE:
-            EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
+            EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0,
                    static_cast<void *>(udata));
         case WRITE:
-            EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
+            EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0,
                    static_cast<void *>(udata));
             break;
         case D_READ:
-            EV_SET(&ev, fd, EVFILT_READ, EV_DISABLE, 0, 0, 0);
+            EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
             break;
         case D_WRITE:
-            EV_SET(&ev, fd, EVFILT_WRITE, EV_DISABLE, 0, 0, 0);
+            EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
+            // EV_SET(&ev, fd, EVFILT_WRITE, EV_DISABLE | EV_ADD, 0, 0, 0);
             break;
         default:
             return;

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -95,7 +95,7 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
                    static_cast<void *>(udata));
             break;
         case EXCUTE:
-            EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0,
+            EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD, 0, 0,
                    static_cast<void *>(udata));
         case WRITE:
             EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0,

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -42,7 +42,7 @@ void EventHandler::garbageCollector() {
 void EventHandler::handleEvent(int event_idx) {
     Event event = _ev_list[event_idx];
     Udata *udata = static_cast<Udata *>(event.udata);
-    e_event action = udata ? udata->action : ACCEPT;
+    e_event action = udata ? udata->action : IDLE;
 
     if ((event.flags & EV_EOF) && udata && !isConnected(udata)) {
         // TODO : ctrl-D 처리
@@ -68,10 +68,10 @@ void EventHandler::handleEvent(int event_idx) {
         case WRITE:
             handleWrite(event_idx);  // TODO
             break;
-        default:
-            std::cout << "client #" << _ev_list[event_idx].ident
-                      << " (unknown event occured)" << std::endl;
-            break;
+            // default:
+            //     std::cout << "client #" << _ev_list[event_idx].ident
+            //               << " (unknown event occured)" << std::endl;
+            //     break;
     }
 }
 
@@ -83,7 +83,8 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
     if (udata) udata->action = action;
     switch (action) {
         case ACCEPT:
-            EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, 0);
+            EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
+                   static_cast<void *>(udata));
             break;
         case CONNECT:
             EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -68,10 +68,10 @@ void EventHandler::handleEvent(int event_idx) {
         case WRITE:
             handleWrite(event_idx);  // TODO
             break;
-            // default:
-            //     std::cout << "client #" << _ev_list[event_idx].ident
-            //               << " (unknown event occured)" << std::endl;
-            //     break;
+        default:
+            std::cout << "client #" << _ev_list[event_idx].ident
+                      << " (unknown event occured)" << std::endl;
+            break;
     }
 }
 
@@ -83,15 +83,15 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
     if (udata) udata->action = action;
     switch (action) {
         case ACCEPT:
-            EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
+            EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0,
                    static_cast<void *>(udata));
             break;
         case CONNECT:
-            EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
+            EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0,
                    static_cast<void *>(udata));
             break;
         case READ:
-            EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
+            EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0,
                    static_cast<void *>(udata));
             break;
         case EXCUTE:
@@ -100,13 +100,6 @@ void EventHandler::registerEvent(int fd, e_event action, Udata *udata) {
         case WRITE:
             EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0,
                    static_cast<void *>(udata));
-            break;
-        case D_READ:
-            EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
-            break;
-        case D_WRITE:
-            EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
-            // EV_SET(&ev, fd, EVFILT_WRITE, EV_DISABLE | EV_ADD, 0, 0, 0);
             break;
         default:
             return;


### PR DESCRIPTION
## 개요
문제점 : 어떤 handler 를 사용할지 분기될 때 사용하는 식별값(Udata::action)을 되는 값을 공용으로 사용
- 사전 지식 : kqueue에 등록되는 이벤트 식별은 <ident, filt, optional udate> 로 이루어짐
- 이전 코드 : 하나의 connected socket 에 대해 kqueue에 등록할 수 있는 이벤트
  - readable 감지를 위해 <fd, EVFILT_READ> 등록
    - `handleAccept`, `handleConnect`, `handleRead`
  - writable 감지를 위해 <fd, EVFILT_WRITE> 등록
    - `handleExecute`, `handleWrite`
  - 이벤트 등록시 Udata::action 를 업데이트해서 어떤 handling을 할지 구분하는 용도로 사용
    - 이벤트 등록 `udata->action = ACCEPT`
    - 이벤트 감지 `switch(udata->action) { case ACCEPT:...`
- [문제 발생] 하나의 connected socket 은 하나의 udata를 가짐
   - kqueue에 <fd, EVFILT_READ>, <fd, EVFILT_WRITE> 가 등록되어 있을 때, 나중에 등록된 이벤트에 대하여 최종적으로 "Udata::action" 이 업데이트됨
    - 즉, <fd, EVFILT_WRITE> 이벤트인데, udata->action 이 READ 여서 `handleRead`가 동작 하는 경우가 발생
## 작업내용
- Udata::action -> Udata::r_action, Udata::w_action 
  - r_action 으로 ACCEPT, CONNECT, READ 가 올 수 있음            (readable case)
  - w_action 으로 EXECUTOR, WRITE, DEL_WRITE 가 올 수 있음 (writable case)
- registerEvent 에 어떤 EVFILT 를 사용할지 알려주는 매개변수 추가
  - filt 가 FILT_READ 이면 r_action 업데이트
  - filt 가 FILT_WRITE 이면 w_action 업데이트
- 
## 주의사항
- [ ] execute 후에 바로 response 를 send해보고(handleExecute에서 send 시도), 문제시 handleWrite 에서 처리
- 수정 내용과 파생된 TODO 코멘트 달아주세요
  - [ ] channelController, clientController
  - [ ] new Command
  - [ ] Client::~Clinet