### PR TITLE
[Feature] Parsing error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Create ft_irc_lib interface
-add_library(ft_irc_lib STATIC src/entity/Channel.cpp src/entity/Client.cpp src/handler/EventHandler.cpp src/core/Server.cpp src/core/Socket.cpp src/controller/ChannelController.cpp src/controller/ClientController.cpp include/controller/Executor.hpp src/controller/Executor.cpp src/core/Udata.cpp src/core/Parser.cpp src/core/utility.cpp include/handler/ResponseHandler.hpp src/handler/ErrorHandler.cpp include/handler/ResponseHandler.hpp include/handler/ErrorHandler.hpp)
+add_library(ft_irc_lib STATIC src/entity/Channel.cpp src/entity/Client.cpp src/handler/EventHandler.cpp src/core/Server.cpp src/core/Socket.cpp src/controller/ChannelController.cpp src/controller/ClientController.cpp include/controller/Executor.hpp src/controller/Executor.cpp src/core/Udata.cpp src/core/Parser.cpp src/core/utility.cpp include/handler/ResponseHandler.hpp src/handler/ErrorHandler.cpp include/handler/ResponseHandler.hpp)
 # Include ft_irc hpp files
 target_include_directories(ft_irc_lib PUBLIC include)
 # Set ft_irc_lib compile option

--- a/include/core/Parser.hpp
+++ b/include/core/Parser.hpp
@@ -21,7 +21,7 @@ class Parser {
     int getToken(int flag);
     bool isEOF();
 
-    static bool validSpecial(char c);
+    static bool isSpecial(char c);
     static std::string &validChannelName(std::string &channel);
     static std::vector<std::string> &validChannelName(
         std::vector<std::string> &channels);
@@ -44,10 +44,31 @@ class Parser {
 
     void parse(const std::string &command_line, e_cmd &cmd, params *&params);
 
-    class UnknownCommandException : public std::exception {};
-    class NotEnoughParamsException : public std::exception {};
-    class InvalidChannelNameException : public std::exception {};
-    class InvalidNickNameException : public std::exception {};
+    class SyntaxException : public std::exception {
+       protected:
+        std::string _cause;
+       public:
+        SyntaxException(const std::string &cause);
+        ~SyntaxException() throw();
+
+        std::string getCause();
+    };
+    class UnknownCommandException : public SyntaxException {
+       public:
+        UnknownCommandException(std::string cause) : SyntaxException(cause) {};
+    };
+    class NotEnoughParamsException : public SyntaxException {
+       public:
+        NotEnoughParamsException(std::string cause) : SyntaxException(cause) {};
+    };
+    class InvalidChannelNameException : public SyntaxException {
+       public:
+        InvalidChannelNameException(std::string cause) : SyntaxException(cause) {};
+    };
+    class InvalidNickNameException : public SyntaxException {
+       public:
+        InvalidNickNameException(std::string cause) : SyntaxException(cause) {};
+    };
 };
 
 }  // namespace ft

--- a/include/core/Parser.hpp
+++ b/include/core/Parser.hpp
@@ -56,6 +56,7 @@ class Parser {
     class UnknownCommandException : public SyntaxException {
        public:
         UnknownCommandException(std::string cause) : SyntaxException(cause) {};
+
     };
     class NotEnoughParamsException : public SyntaxException {
        public:

--- a/include/handler/ErrorHandler.hpp
+++ b/include/handler/ErrorHandler.hpp
@@ -43,69 +43,9 @@ class ErrorHandler {
     static const std::string ERR_BADCHANMASK_MSG;
 
    public:
-    /**
-     * @brief Handle error add error response to send_buf
-     * @param client client source
-     * @param cause cause of error (command or param)
-     * @param code error code
-     */
-    static void handleError(Client *client, std::string cause, e_err_code code) {
-        std::stringstream res_stream;
-        std::string res;
-        std::string msg = getErrorMessage(code);
-
-        res_stream << ":" << servername << " " << code
-                   << " " << client->getNickname() << " " << cause
-                   << " :\"" << msg << "\"";
-        res = res_stream.str();
-        client->send_buf.append(res);
-    }
-    static void handleError(std::exception &e, Client *src) {
-        if (Parser::UnknownCommandException *uce = dynamic_cast<Parser::UnknownCommandException *>(&e))
-            handleError(src, uce->getCause(), ERR_UNKNOWNCOMMAND);
-        else if (Parser::NotEnoughParamsException *nepe = dynamic_cast<Parser::NotEnoughParamsException *>(&e))
-            handleError(src, nepe->getCause(), ERR_NEEDMOREPARAMS);
-        else if (Parser::InvalidChannelNameException *icne = dynamic_cast<Parser::InvalidChannelNameException *>(&e))
-            handleError(src, icne->getCause(), ERR_BADCHANMASK);
-        else if (Parser::InvalidNickNameException *inne = dynamic_cast<Parser::InvalidNickNameException *>(&e))
-            handleError(src, inne->getCause(), ERR_ERRONEUSNICKNAME);
-        else
-            std::cout << "ErrorHandler: Unknown error occurred" << std::endl;
-
-    }
-
-    static std::string getErrorMessage(e_err_code code) {
-        switch (code) {
-            case ERR_UNKNOWNMODE:
-                return ERR_UNKNOWNCOMMAND_MSG;
-            case ERR_NEEDMOREPARAMS:
-                return ERR_NEEDMOREPARAMS_MSG;
-            case ERR_ALREADYREGISTERED:
-                return ERR_ALREADYREGISTERED_MSG;
-            case ERR_NONICKNAMEGIVEN:
-                return ERR_NONICKNAMEGIVEN_MSG;
-            case ERR_ERRONEUSNICKNAME:
-                return ERR_ERRONEUSNICKNAME_MSG;
-            case ERR_NICKNAMEINUSE:
-                return ERR_NICKNAMEINUSE_MSG;
-            case ERR_NOTONCHANNEL:
-                return ERR_NOTONCHANNEL_MSG;
-            case ERR_USERONCHANNEL:
-                return ERR_USERONCHANNEL_MSG;
-            case ERR_INVITEONLYCHAN:
-                return ERR_INVITEONLYCHAN_MSG;
-            case ERR_CHANOPRIVSNEEDED:
-                return ERR_CHANOPRIVSNEEDED_MSG;
-            case ERR_NOSUCHNICK:
-                return ERR_NOSUCHNICK_MSG;
-            case ERR_NOSUCHCHANNEL:
-                return ERR_NOSUCHCHANNEL_MSG;
-            case ERR_BADCHANMASK:
-                return ERR_BADCHANMASK_MSG;
-            default:
-                return "Unknown error code";
-        }
-    }
+    static void handleError(Client *client, std::string cause, e_err_code code);
+    static void handleError(std::exception &e, Client *src);
+    static std::string getErrorMessage(e_err_code code);
 };
 
 const std::string ErrorHandler::servername = "eyeRsee.local";

--- a/include/handler/ErrorHandler.hpp
+++ b/include/handler/ErrorHandler.hpp
@@ -54,7 +54,7 @@ class ErrorHandler {
         std::string res;
         std::string msg = getErrorMessage(code);
 
-        res_stream << ":" << servername << " " << std::to_string(code)
+        res_stream << ":" << servername << " " << code
                    << " " << client->getNickname() << " " << cause
                    << " :\"" << msg << "\"";
         res = res_stream.str();

--- a/include/handler/ErrorHandler.hpp
+++ b/include/handler/ErrorHandler.hpp
@@ -2,10 +2,10 @@
 #define ERRORHANDLER_HPP
 
 #include <string>
-#include "entity/Client.hpp"
-#include "core/Parser.hpp"
 
 namespace ft {
+
+class Client;
 
 class ErrorHandler {
     enum e_err_code {
@@ -47,24 +47,6 @@ class ErrorHandler {
     static void handleError(std::exception &e, Client *src);
     static std::string getErrorMessage(e_err_code code);
 };
-
-const std::string ErrorHandler::servername = "eyeRsee.local";
-
-const std::string ErrorHandler::ERR_UNKNOWNCOMMAND_MSG = "Unknown command";
-const std::string ErrorHandler::ERR_NEEDMOREPARAMS_MSG = "Not enough parameters";
-
-const std::string ErrorHandler::ERR_ALREADYREGISTERED_MSG = "You may not reregister";
-const std::string ErrorHandler::ERR_NONICKNAMEGIVEN_MSG = "No nickname given";
-const std::string ErrorHandler::ERR_ERRONEUSNICKNAME_MSG = "Erroneus nickname";
-const std::string ErrorHandler::ERR_NICKNAMEINUSE_MSG = "Nickname is already in use";
-const std::string ErrorHandler::ERR_NOTONCHANNEL_MSG = "You're not on that channel";
-const std::string ErrorHandler::ERR_USERONCHANNEL_MSG = "is already on channel";
-const std::string ErrorHandler::ERR_UNKNOWNMODE_MSG = "is unknown mode char to me";
-const std::string ErrorHandler::ERR_INVITEONLYCHAN_MSG = "Cannot join channel (+i)";
-const std::string ErrorHandler::ERR_CHANOPRIVSNEEDED_MSG = "You're not channel operator";
-const std::string ErrorHandler::ERR_NOSUCHNICK_MSG = "No such nick/channel";
-const std::string ErrorHandler::ERR_NOSUCHCHANNEL_MSG = "No such channel";
-const std::string ErrorHandler::ERR_BADCHANMASK_MSG = "Invalid channel name";
 
 }
 

--- a/src/core/Parser.cpp
+++ b/src/core/Parser.cpp
@@ -22,10 +22,10 @@ bool isSpecial(char c) {
 }
 std::string &Parser::validChannelName(std::string &channel) {
     // chstring any string except for SPACE, BELL, NUL, CR, LF and comma(',')
-    if (channel.size() > 200) throw InvalidChannelNameException();
+    if (channel.size() > 200) throw InvalidChannelNameException(channel);
     for (int i = 0; i < channel.length(); i++) {
         if (!isascii(channel[i]) || isspace(channel[i]) || channel[i] == ',')
-            throw InvalidChannelNameException();
+            throw InvalidChannelNameException(channel);
     }
     return channel;
 }
@@ -38,12 +38,12 @@ std::vector<std::string> &Parser::validChannelName(std::vector<std::string> &cha
 }
 std::string &Parser::validNickName(std::string &nickname) {
     // <letter> { <letter> | <number> | <special> }
-    if (nickname.length() > 9) throw InvalidNickNameException();
+    if (nickname.length() > 9) throw InvalidNickNameException(nickname);
     if (!isalpha(nickname[0]))
-        throw InvalidNickNameException();
+        throw InvalidNickNameException(nickname);
     for (int i = 1; i < nickname.length(); i++) {
         if (!isalnum(nickname[i]) && !isSpecial(nickname[i]))
-            throw InvalidNickNameException();
+            throw InvalidNickNameException(nickname);
     }
     return nickname;
 }
@@ -65,7 +65,7 @@ void Parser::parsePass(e_cmd &cmd, params *&params) {
         p = new pass_params;
         p->password = token;
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("PASS");
     }
     params = p;
 }
@@ -106,7 +106,7 @@ void Parser::parseJoin(e_cmd &cmd, params *&params) {
             p->keys = keys;
         }
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("JOIN");
     }
     params = p;
 }
@@ -119,7 +119,7 @@ void Parser::parsePart(e_cmd &cmd, params *&params) {
 
         p->channels = validChannelName(channels);
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("PART");
     }
     params = p;
 }
@@ -147,10 +147,10 @@ void Parser::parseMode(e_cmd &cmd, params *&params) {
             if (!isEOF() && getToken())
                 p->nickname = validNickName(token);
         } else {
-            throw NotEnoughParamsException();
+            throw NotEnoughParamsException("MODE");
         }
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("MODE");
     }
     params = p;
 }
@@ -159,7 +159,7 @@ void Parser::parseInvite(e_cmd &cmd, params *&params) {
     invite_params *p;
     std::vector<std::string> tokens = split(tokenStream, ' ');
 
-    if (tokens.size() != 2) throw std::logic_error("Argument must be 2");
+    if (tokens.size() != 2) throw NotEnoughParamsException("INVITE");
 
     p->nickname = validNickName(tokens[0]);
     p->channel = validChannelName(tokens[1]);
@@ -180,10 +180,10 @@ void Parser::parseKick(e_cmd &cmd, params *&params) {
             }
         } else {
             delete p;
-            throw NotEnoughParamsException();
+            throw NotEnoughParamsException("KICK");
         }
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("KICK");
     }
     params = p;
 }
@@ -193,7 +193,7 @@ void Parser::parseTopic(e_cmd &cmd, params *&params) {
 
     std::vector<std::string> tokens = split(tokenStream, ' ');
     if (!(tokens.size() == 1 || tokens.size() == 2)) {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("TOPIC");
     }
     p = new topic_params;
 
@@ -215,10 +215,10 @@ void Parser::parsePrivmsg(e_cmd &cmd, params *&params) {
             p->msg = token;
         } else {
             delete p;
-            throw NotEnoughParamsException();
+            throw NotEnoughParamsException("PRIVMSG");
         }
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("PRIVMSG");
     }
     params = p;
 }
@@ -232,10 +232,10 @@ void Parser::parseNotice(e_cmd &cmd, params *&params) {
             p->msg = token;
         } else {
             delete p;
-            throw NotEnoughParamsException();
+            throw NotEnoughParamsException("NOTICE");
         }
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("NOTICE");
     }
     params = p;
 }
@@ -246,7 +246,7 @@ void Parser::parsePing(e_cmd &cmd, params *&params) {
     if (!isEOF() && getToken()) {
         p->servername = token;
     } else {
-        throw NotEnoughParamsException();
+        throw NotEnoughParamsException("PING");
     }
     params = p;
 }
@@ -282,7 +282,7 @@ void Parser::parse(const std::string &command_line, e_cmd &cmd, params *&params)
     } else if (token == "PING") {
         parsePing(cmd, params);
     } else {
-        throw UnknownCommandException();
+        throw UnknownCommandException(token);
     }
     tokenStream.clear();
 }

--- a/src/core/Parser.cpp
+++ b/src/core/Parser.cpp
@@ -14,7 +14,7 @@ bool Parser::isEOF() {
     return false;
 }
 
-bool isSpecial(char c) {
+bool Parser::isSpecial(char c) {
     if (c == '-' || c == '[' || c == ']' || c == '\\'
         || c == '`' || c == '^' || c == '{' || c == '}')
         return true;
@@ -286,5 +286,9 @@ void Parser::parse(const std::string &command_line, e_cmd &cmd, params *&params)
     }
     tokenStream.clear();
 }
+
+Parser::SyntaxException::SyntaxException(const std::string &cause) : _cause(cause) {}
+Parser::SyntaxException::~SyntaxException() throw() {}
+std::string Parser::SyntaxException::getCause() { return _cause; }
 
 } // namespace ft

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -27,7 +27,7 @@ void Env::parse(int argc, char **argv) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     d_port = std::strtod(port_str.c_str(), &back);
-    if (*back || d_port<1025 | d_port> 65535) {
+    if (*back || d_port < 1025 | d_port > 65535) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     }
@@ -96,16 +96,16 @@ void Server::handleConnect(int event_idx) {
     ssize_t n;
     Event event = _ev_list[event_idx];
     Udata *udata = static_cast<Udata *>(event.udata);
-    Client *new_client = udata->src;
+    ConnectSocket *connect_socket = udata->src;
 
     // read connect_socket
     n = recv(event.ident, &buf, BUF_SIZE, 0);
     buf[n] = 0;
 
-    new_client->recv_buf.append(buf);
+    connect_socket->recv_buf.append(buf);
 
     // multi commands parse
-    std::string line = new_client->readRecvBuf();
+    std::string line = connect_socket->readRecvBuf();
     std::vector<std::string> command_lines = split(line, '\n');
     std::vector<std::string>::iterator it;
     for (it = command_lines.begin(); it != command_lines.end(); it++) {
@@ -115,7 +115,7 @@ void Server::handleConnect(int event_idx) {
             _parser.parse(*it, command->type, command->params);
             udata->commands.push_back(command);
         } catch (std::exception &e) {
-            ErrorHandler::handleError(e, new_client);
+            ErrorHandler::handleError(e, udata->src);
         }
     }
 
@@ -123,12 +123,12 @@ void Server::handleConnect(int event_idx) {
     // authenticate error
     std::vector<Command *>::iterator iter = udata->commands.begin();
     for (; iter != udata->commands.end(); ++iter) {
-        _executor.connect(*iter, new_client, _env.password);
+        _executor.connect(*iter, udata->src, _env.password);
     }
     udata->commands.clear();
 
     // check is authenticate
-    if (new_client->isAuthenticate()) {
+    if (udata->src->isAuthenticate()) {
         _tmp_garbage.erase(udata);
         send(event.ident, WELCOME_PROMPT, strlen(WELCOME_PROMPT), 0);
         registerEvent(event.ident, EVFILT_READ, READ, udata);
@@ -144,7 +144,7 @@ void Server::handleRead(int event_idx) {
     ssize_t n = 0;
     Event event = _ev_list[event_idx];
     Udata *udata = static_cast<Udata *>(event.udata);
-    Client *client = udata->src;
+    ConnectSocket *connect_socket = udata->src;
 
     n = recv(event.ident, &buf, BUF_SIZE, 0);
     if (n == -1) {
@@ -153,10 +153,10 @@ void Server::handleRead(int event_idx) {
     }
     buf[n] = 0;
 
-    client->recv_buf.append(buf);
+    connect_socket->recv_buf.append(buf);
 
     // multi commands parse
-    std::string line = client->readRecvBuf();
+    std::string line = connect_socket->readRecvBuf();
     std::vector<std::string> command_lines = split(line, '\n');
 
     std::vector<std::string>::iterator it;
@@ -167,7 +167,7 @@ void Server::handleRead(int event_idx) {
             _parser.parse(*it, command->type, command->params);
             udata->commands.push_back(command);
         } catch (std::exception &e) {
-            ErrorHandler::handleError(e, client);
+            ErrorHandler::handleError(e, udata->src);
         }
     }
 

--- a/src/handler/ErrorHandler.cpp
+++ b/src/handler/ErrorHandler.cpp
@@ -1,4 +1,70 @@
 #include "core/Parser.hpp"
+#include "handler/ErrorHandler.hpp"
 
 namespace ft {
+
+/**
+ * @brief Handle error add error response to send_buf
+ * @param client client source
+ * @param cause cause of error (command or param)
+ * @param code error code
+ */
+void ErrorHandler::handleError(Client *client, std::string cause, e_err_code code) {
+    std::stringstream res_stream;
+    std::string res;
+    std::string msg = getErrorMessage(code);
+
+    res_stream << ":" << servername << " " << code
+               << " " << client->getNickname() << " " << cause
+               << " :\"" << msg << "\"";
+    res = res_stream.str();
+    client->send_buf.append(res);
+}
+void ErrorHandler::handleError(std::exception &e, Client *src) {
+    if (Parser::UnknownCommandException *uce = dynamic_cast<Parser::UnknownCommandException *>(&e))
+        handleError(src, uce->getCause(), ERR_UNKNOWNCOMMAND);
+    else if (Parser::NotEnoughParamsException *nepe = dynamic_cast<Parser::NotEnoughParamsException *>(&e))
+        handleError(src, nepe->getCause(), ERR_NEEDMOREPARAMS);
+    else if (Parser::InvalidChannelNameException *icne = dynamic_cast<Parser::InvalidChannelNameException *>(&e))
+        handleError(src, icne->getCause(), ERR_BADCHANMASK);
+    else if (Parser::InvalidNickNameException *inne = dynamic_cast<Parser::InvalidNickNameException *>(&e))
+        handleError(src, inne->getCause(), ERR_ERRONEUSNICKNAME);
+    else
+        std::cout << "ErrorHandler: Unknown error occurred" << std::endl;
+
+}
+
+std::string ErrorHandler::getErrorMessage(e_err_code code) {
+    switch (code) {
+        case ERR_UNKNOWNMODE:
+            return ERR_UNKNOWNCOMMAND_MSG;
+        case ERR_NEEDMOREPARAMS:
+            return ERR_NEEDMOREPARAMS_MSG;
+        case ERR_ALREADYREGISTERED:
+            return ERR_ALREADYREGISTERED_MSG;
+        case ERR_NONICKNAMEGIVEN:
+            return ERR_NONICKNAMEGIVEN_MSG;
+        case ERR_ERRONEUSNICKNAME:
+            return ERR_ERRONEUSNICKNAME_MSG;
+        case ERR_NICKNAMEINUSE:
+            return ERR_NICKNAMEINUSE_MSG;
+        case ERR_NOTONCHANNEL:
+            return ERR_NOTONCHANNEL_MSG;
+        case ERR_USERONCHANNEL:
+            return ERR_USERONCHANNEL_MSG;
+        case ERR_INVITEONLYCHAN:
+            return ERR_INVITEONLYCHAN_MSG;
+        case ERR_CHANOPRIVSNEEDED:
+            return ERR_CHANOPRIVSNEEDED_MSG;
+        case ERR_NOSUCHNICK:
+            return ERR_NOSUCHNICK_MSG;
+        case ERR_NOSUCHCHANNEL:
+            return ERR_NOSUCHCHANNEL_MSG;
+        case ERR_BADCHANMASK:
+            return ERR_BADCHANMASK_MSG;
+        default:
+            return "Unknown error code";
+    }
+}
+
 } // namespace ft

--- a/src/handler/ErrorHandler.cpp
+++ b/src/handler/ErrorHandler.cpp
@@ -1,5 +1,7 @@
-#include "core/Parser.hpp"
 #include "handler/ErrorHandler.hpp"
+
+#include "core/Parser.hpp"
+#include "entity/Client.hpp"
 
 namespace ft {
 
@@ -9,29 +11,33 @@ namespace ft {
  * @param cause cause of error (command or param)
  * @param code error code
  */
-void ErrorHandler::handleError(Client *client, std::string cause, e_err_code code) {
+void ErrorHandler::handleError(Client *client, std::string cause,
+                               e_err_code code) {
     std::stringstream res_stream;
     std::string res;
     std::string msg = getErrorMessage(code);
 
-    res_stream << ":" << servername << " " << code
-               << " " << client->getNickname() << " " << cause
-               << " :\"" << msg << "\"";
+    res_stream << ":" << servername << " " << code << " "
+               << client->getNickname() << " " << cause << " :\"" << msg
+               << "\"";
     res = res_stream.str();
     client->send_buf.append(res);
 }
 void ErrorHandler::handleError(std::exception &e, Client *src) {
-    if (Parser::UnknownCommandException *uce = dynamic_cast<Parser::UnknownCommandException *>(&e))
+    if (Parser::UnknownCommandException *uce =
+            dynamic_cast<Parser::UnknownCommandException *>(&e))
         handleError(src, uce->getCause(), ERR_UNKNOWNCOMMAND);
-    else if (Parser::NotEnoughParamsException *nepe = dynamic_cast<Parser::NotEnoughParamsException *>(&e))
+    else if (Parser::NotEnoughParamsException *nepe =
+                 dynamic_cast<Parser::NotEnoughParamsException *>(&e))
         handleError(src, nepe->getCause(), ERR_NEEDMOREPARAMS);
-    else if (Parser::InvalidChannelNameException *icne = dynamic_cast<Parser::InvalidChannelNameException *>(&e))
+    else if (Parser::InvalidChannelNameException *icne =
+                 dynamic_cast<Parser::InvalidChannelNameException *>(&e))
         handleError(src, icne->getCause(), ERR_BADCHANMASK);
-    else if (Parser::InvalidNickNameException *inne = dynamic_cast<Parser::InvalidNickNameException *>(&e))
+    else if (Parser::InvalidNickNameException *inne =
+                 dynamic_cast<Parser::InvalidNickNameException *>(&e))
         handleError(src, inne->getCause(), ERR_ERRONEUSNICKNAME);
     else
         std::cout << "ErrorHandler: Unknown error occurred" << std::endl;
-
 }
 
 std::string ErrorHandler::getErrorMessage(e_err_code code) {
@@ -67,4 +73,29 @@ std::string ErrorHandler::getErrorMessage(e_err_code code) {
     }
 }
 
-} // namespace ft
+const std::string ErrorHandler::servername = "eyeRsee.local";
+
+const std::string ErrorHandler::ERR_UNKNOWNCOMMAND_MSG = "Unknown command";
+const std::string ErrorHandler::ERR_NEEDMOREPARAMS_MSG =
+    "Not enough parameters";
+
+const std::string ErrorHandler::ERR_ALREADYREGISTERED_MSG =
+    "You may not reregister";
+const std::string ErrorHandler::ERR_NONICKNAMEGIVEN_MSG = "No nickname given";
+const std::string ErrorHandler::ERR_ERRONEUSNICKNAME_MSG = "Erroneus nickname";
+const std::string ErrorHandler::ERR_NICKNAMEINUSE_MSG =
+    "Nickname is already in use";
+const std::string ErrorHandler::ERR_NOTONCHANNEL_MSG =
+    "You're not on that channel";
+const std::string ErrorHandler::ERR_USERONCHANNEL_MSG = "is already on channel";
+const std::string ErrorHandler::ERR_UNKNOWNMODE_MSG =
+    "is unknown mode char to me";
+const std::string ErrorHandler::ERR_INVITEONLYCHAN_MSG =
+    "Cannot join channel (+i)";
+const std::string ErrorHandler::ERR_CHANOPRIVSNEEDED_MSG =
+    "You're not channel operator";
+const std::string ErrorHandler::ERR_NOSUCHNICK_MSG = "No such nick/channel";
+const std::string ErrorHandler::ERR_NOSUCHCHANNEL_MSG = "No such channel";
+const std::string ErrorHandler::ERR_BADCHANMASK_MSG = "Invalid channel name";
+
+}  // namespace ft


### PR DESCRIPTION
## 개요
- Parsing error handing 작업 완료

## 작업내용
- 에러 내용(command, param) 을 확인하기 위한 `SyntaxException` 클래스 생성
- 기존에 이야기 했었던 `send_buf` 로만 해결하는데에 문제가 있었음 -> `Exception` 으로 해결
  - `Parse` 안에서 `client` 를 받아야하는 문제
  - `command | parse` 를 넘겨야하는 문제

## 주의사항