### PR TITLE
[FIX] add EventHandler::udata_list

### DIFF
--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -31,6 +31,7 @@ class Executor {
     Executor &operator=(const Executor &ref);
 
     const std::set<int> &getFdList() const;
+    void clearFdLIst();
 
     Client *accept(int fd);
     void connect(Command *command, Client *client, std::string password);

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -50,7 +50,6 @@ class Server : public EventHandler {
 
     // handler methods
     void handleAccept();
-    void handleConnect(int event_idx);
     void handleRead(int event_idx);
     void handleExecute(int event_idx);
     void handleTimer(int event_idx);

--- a/include/core/Socket.hpp
+++ b/include/core/Socket.hpp
@@ -36,6 +36,7 @@ class ListenSocket : public SocketBase {
 
 class ConnectSocket : public SocketBase {
    public:
+    e_status status;
     std::string recv_buf;
     std::string send_buf;
     bool auth[3];

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -2,16 +2,9 @@
 #define TYPE_HPP
 
 namespace ft {
-enum e_event {
-    ACCEPT,
-    CONNECT,
-    READ,
-    EXECUTE,
-    TIMER,
-    D_WRITE,
-    D_TIMER,
-    IDLE
-};
+enum e_event { ACCEPT, READ, EXECUTE, TIMER, D_WRITE, D_TIMER, IDLE };
+
+enum e_status { UNREGISTER, REGISTER };
 
 enum e_cmd {
     PASS,

--- a/include/core/Udata.hpp
+++ b/include/core/Udata.hpp
@@ -74,9 +74,6 @@ struct Command {
 };
 
 struct Udata {
-    e_event timer;
-    e_event r_action;
-    e_event w_action;
     int status;
     std::vector<Command *> commands;
     Client *src;

--- a/include/core/Udata.hpp
+++ b/include/core/Udata.hpp
@@ -74,7 +74,6 @@ struct Command {
 };
 
 struct Udata {
-    int status;
     std::vector<Command *> commands;
     Client *src;
 

--- a/include/handler/EventHandler.hpp
+++ b/include/handler/EventHandler.hpp
@@ -42,7 +42,6 @@ class EventHandler {
     // handle functions
     void handleEvent(int event_idx);
     virtual void handleAccept() = 0;
-    virtual void handleConnect(int event_idx) = 0;
     virtual void handleRead(int event_idx) = 0;
     virtual void handleExecute(int event_idx) = 0;
     virtual void handleTimer(int event_idx) = 0;

--- a/include/handler/EventHandler.hpp
+++ b/include/handler/EventHandler.hpp
@@ -3,6 +3,7 @@
 
 #include <sys/event.h>
 
+#include <map>
 #include <set>
 #include <vector>
 
@@ -20,11 +21,12 @@ class EventHandler {
     int _kq_fd;
     int _change_cnt;
 
-    std::set<Udata *> _tmp_garbage;  // timeout
-    std::set<Udata *> _garbage;      // client gone
-
     Event _ev_list[_max_event];
     EventList _change_list;
+
+    std::map<int, Udata *> _udata_list;
+    std::set<Udata *> _tmp_garbage;  // timeout
+    std::set<Udata *> _garbage;      // client gone
 
    public:
     EventHandler();

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -23,6 +23,7 @@ Channel *Executor::createChannel(std::string channel_name) {
 }
 
 const std::set<int> &Executor::getFdList() const { return _fd_list; }
+void Executor::clearFdLIst() { _fd_list.clear(); }
 
 void Executor::deleteClient(Client *client) {
     ChannelController::ChannelList channel_list;
@@ -55,7 +56,8 @@ void Executor::connect(Command *command, Client *client, std::string password) {
         default:
             // TODO : msg
             send(client->getFd(),
-                 ":eyeRsee.local 451 * JOIN :You have not registered.\n", 53, 0);
+                 ":eyeRsee.local 451 * JOIN :You have not registered.\n", 53,
+                 0);
             break;
     }
 }
@@ -370,10 +372,11 @@ void Executor::notice(Client *client, params *params) {
     notice_params *p = dynamic_cast<notice_params *>(params);
 
     Client *receiver = client_controller.find(p->nickname);
-    if (receiver)
+    if (receiver) {
         ResponseHandler::handleResponse(receiver, "NOTICE",
                                         client->getNickname(), p->msg);
-    else
+        _fd_list.insert(receiver->getFd());
+    } else
         ErrorHandler::handleError(client, p->nickname, ERR_NOSUCHNICK);
 }
 

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -5,8 +5,8 @@
 
 #include "entity/Channel.hpp"
 #include "entity/Client.hpp"
-#include "handler/ResponseHandler.hpp"
 #include "handler/ErrorHandler.hpp"
+#include "handler/ResponseHandler.hpp"
 
 namespace ft {
 
@@ -22,9 +22,7 @@ Channel *Executor::createChannel(std::string channel_name) {
     return channel_controller.insert(channel_name);
 }
 
-const std::set<int> &Executor::getFdList() const {
-    return _fd_list;
-}
+const std::set<int> &Executor::getFdList() const { return _fd_list; }
 
 void Executor::deleteClient(Client *client) {
     ChannelController::ChannelList channel_list;
@@ -55,8 +53,9 @@ void Executor::connect(Command *command, Client *client, std::string password) {
             nick(client, command->params);
             break;
         default:
-            std::cout << ":eyeRsee.local 451 * JOIN :You have not registered."
-                      << std::endl;
+            // TODO : msg
+            send(client->getFd(),
+                 ":eyeRsee.local 451 * JOIN :You have not registered.\n", 53, 0);
             break;
     }
 }
@@ -227,7 +226,7 @@ void Executor::user(Client *new_client, params *params) {
 }
 
 /**
- * @brief only used in handleConnect
+ * @brief only used in connection registration
  */
 void Executor::nick(Client *new_client, params *params) {
     std::string nickname = dynamic_cast<nick_params *>(params)->nickname;
@@ -372,7 +371,8 @@ void Executor::notice(Client *client, params *params) {
 
     Client *receiver = client_controller.find(p->nickname);
     if (receiver)
-        ResponseHandler::handleResponse(receiver, "NOTICE", client->getNickname(), p->msg);
+        ResponseHandler::handleResponse(receiver, "NOTICE",
+                                        client->getNickname(), p->msg);
     else
         ErrorHandler::handleError(client, p->nickname, ERR_NOSUCHNICK);
 }
@@ -381,7 +381,8 @@ void Executor::pong(Client *client, params *params) {
     //: NAYEON.local PONG NAYEON.local :NAYEON.local
     ping_params *p = dynamic_cast<ping_params *>(params);
 
-    ResponseHandler::handleResponse(client, "PONG", p->servername, p->servername);
+    ResponseHandler::handleResponse(client, "PONG", p->servername,
+                                    p->servername);
 }
 
 }  // namespace ft

--- a/src/core/Parser.cpp
+++ b/src/core/Parser.cpp
@@ -262,6 +262,7 @@ void Parser::parse(const std::string &command_line, e_cmd &cmd, params *&params)
     tokenStream.str(command_line);
     getToken();
 
+
     if (token == "QUIT") {
         parseQuit(cmd, params);
     } else if (token == "PASS") {

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -26,7 +26,7 @@ void Env::parse(int argc, char **argv) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     d_port = std::strtod(port_str.c_str(), &back);
-    if (*back || d_port < 1025 | d_port > 65535) {
+    if (*back || d_port<1025 | d_port> 65535) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     }
@@ -81,56 +81,8 @@ void Server::handleAccept() {
     udata = new Udata;
     udata->src = new_client;
 
-    registerEvent(new_client->getFd(), EVFILT_READ, CONNECT, udata);
+    registerEvent(new_client->getFd(), EVFILT_READ, READ, udata);
     registerEvent(new_client->getFd(), EVFILT_TIMER, TIMER, udata);
-}
-
-void Server::handleConnect(int event_idx) {
-    std::cout << "Connect" << std::endl;
-
-    char buf[BUF_SIZE];
-    ssize_t n;
-    Event event = _ev_list[event_idx];
-    Udata *udata = static_cast<Udata *>(event.udata);
-    ConnectSocket *connect_socket = udata->src;
-
-    // read connect_socket
-    n = recv(event.ident, &buf, BUF_SIZE, 0);
-    buf[n] = 0;
-
-    connect_socket->recv_buf.append(buf);
-
-    // multi commands parse
-    std::string line = connect_socket->readRecvBuf();
-    std::vector<std::string> command_lines = split(line, '\n');
-    std::vector<std::string>::iterator it;
-    for (it = command_lines.begin(); it != command_lines.end(); it++) {
-        Command *command = new Command;
-
-        try {
-            _parser.parse(*it, command->type, command->params);
-            udata->commands.push_back(command);
-        } catch (std::exception &e) {
-            ErrorHandler::handleError(e, udata->src);
-        }
-    }
-
-    // connect to clients logic
-    // authenticate error
-    std::vector<Command *>::iterator iter = udata->commands.begin();
-    for (; iter != udata->commands.end(); ++iter) {
-        _executor.connect(*iter, udata->src, _env.password);
-    }
-    udata->commands.clear();
-
-    // check is authenticate
-    if (connect_socket->isAuthenticate()) {
-        _tmp_garbage.erase(udata);
-        send(event.ident, WELCOME_PROMPT, strlen(WELCOME_PROMPT), 0);
-        registerEvent(event.ident, EVFILT_READ, READ, udata);
-        std::cout << "#" << event.ident << "READ event registered!"
-                  << std::endl;
-    }
 }
 
 void Server::handleRead(int event_idx) {
@@ -144,7 +96,7 @@ void Server::handleRead(int event_idx) {
 
     n = recv(event.ident, &buf, BUF_SIZE, 0);
     if (n == -1) {
-        perror("handleRead (recv -1): ");
+        _garbage.insert(udata);
         return;
     }
     buf[n] = 0;
@@ -167,9 +119,24 @@ void Server::handleRead(int event_idx) {
         }
     }
 
+    if (udata->src->status == REGISTER) {
+        if (command_lines.size())
+            registerEvent(event.ident, EVFILT_WRITE, EXECUTE, udata);
+    } else if (udata->src->status == UNREGISTER) {
+        std::vector<Command *>::iterator iter = udata->commands.begin();
+        for (; iter != udata->commands.end(); ++iter) {
+            _executor.connect(*iter, udata->src, _env.password);
+        }
+        udata->commands.clear();
+
+        // check is authenticate
+        if (connect_socket->isAuthenticate()) {
+            connect_socket->status = REGISTER;
+            _tmp_garbage.erase(udata);
+            send(event.ident, WELCOME_PROMPT, strlen(WELCOME_PROMPT), 0);
+        }
+    }
     // registerRead
-    if (command_lines.size())
-        registerEvent(event.ident, EVFILT_WRITE, EXECUTE, udata);
 }
 
 void Server::handleExecute(int event_idx) {

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -73,7 +73,7 @@ void ListenSocket::createSocket(const int &port) {
 /*                  ConnectSocket                   */
 /****************************************************/
 
-ConnectSocket::ConnectSocket() : SocketBase(-1) {
+ConnectSocket::ConnectSocket() : SocketBase(-1), status(UNREGISTER) {
     recv_buf.reserve(512);
     send_buf.reserve(512);
 }

--- a/src/core/Udata.cpp
+++ b/src/core/Udata.cpp
@@ -9,12 +9,11 @@ Command::~Command() {
     }
 };
 
-Udata::Udata() : status(0), src(NULL) {}
+Udata::Udata() : src(NULL) {}
 Udata::Udata(const Udata &copy) { *this = copy; }
 Udata::~Udata() {}
 
 Udata &Udata::operator=(const Udata &ref) {
-    status = ref.status;
     commands = ref.commands;
     src = ref.src;
 

--- a/src/core/Udata.cpp
+++ b/src/core/Udata.cpp
@@ -9,7 +9,7 @@ Command::~Command() {
     }
 };
 
-Udata::Udata() : r_action(IDLE), w_action(IDLE), status(0), src(NULL) {}
+Udata::Udata() : status(0), src(NULL) {}
 Udata::Udata(const Udata &copy) { *this = copy; }
 Udata::~Udata() {}
 

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -44,11 +44,11 @@ void EventHandler::handleEvent(int event_idx) {
     Udata *udata = static_cast<Udata *>(event.udata);
     e_event action = IDLE;
     if (event.filter == EVFILT_READ)
-        udata ? action = udata->r_action : action = ACCEPT;
+        udata ? action = READ : action = ACCEPT;
     else if (event.filter == EVFILT_WRITE && udata)
-        action = udata->w_action;
+        action = EXECUTE;
     else if (event.filter == EVFILT_TIMER && udata)
-        action = udata->timer;
+        action = TIMER;
 
     if (event.flags & EV_EOF) {
         _tmp_garbage.erase(udata);
@@ -69,8 +69,10 @@ void EventHandler::handleEvent(int event_idx) {
         case TIMER:
             handleTimer(event_idx);
         default:
-            std::cout << "client #" << _ev_list[event_idx].ident
-                      << " (unknown event occured)" << std::endl;
+            std::cout << "client #" << event.ident << "EV_FILT(" << event.filter
+                      << "), "
+                      << "EV_FLAGS(" << event.flags << ""
+                      << ")" << std::endl;
             break;
     }
 }
@@ -81,12 +83,7 @@ void EventHandler::registerEvent(int fd, short filt, e_event action,
     u_short flags = action != D_WRITE && action != D_TIMER ? EV_ADD : EV_DELETE;
     int64_t data = 0;
 
-    if (filt == EVFILT_WRITE) {
-        if (action != D_WRITE) udata->w_action = action;
-    } else if (filt == EVFILT_READ) {
-        if (udata) udata->r_action = action;
-    } else {  // EVFILT_TIMER
-        if (action != D_TIMER) udata->timer = action;
+    if (filt == EVFILT_TIMER && action != D_TIMER) {
         data = 60000;
     }
     EV_SET(&ev, fd, filt, flags, 0, data, static_cast<void *>(udata));

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -60,9 +60,6 @@ void EventHandler::handleEvent(int event_idx) {
         case ACCEPT:
             handleAccept();
             break;
-        case CONNECT:
-            handleConnect(event_idx);
-            break;
         case READ:
             handleRead(event_idx);
             break;


### PR DESCRIPTION
## 개요
- EventHandler::_udata_list 추가
  - 목적 : server에 데이터를 날린 client에 의해 새로운 데이터를 받는 other clients의 Udata 정보 조회
- handleConnect, handleRead 병합
  - 목적 : 코드의 단순화
## 작업내용
- udata_list 사용
- Udata의 action 관련 멤버 변수들  삭제
- ConnectSocket::status 추가 (REGISTER / UNREGISTER) 
## 주의사항
- ConnectSocket::status 가 UNREGISTER 인 경우
  - 해당유저는 REGISTER 관련 command 만 실행할 수 있음
  - 해당유저에게 다른 유저가 privmsg나 notice, invite 등 간섭 할 수 없음
- handleRead 와 handleExecute 를 다른 private 메소드 사용으로 코드 간결화 필요
-[Discussion] ConnectSocket 에서 register 했는지 안했는지 구분하는 변수 외에 다른 방법
  - 현재 : 구조를 최대한 변경하지 않기위해 ConnectSocket::status 추가
  - 제안 : client_controller 에서, _client_list 를 _client_list, _unregister_list 와 같이 나누기