### PR TITLE
[BugFix] msg parse error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Create ft_irc_lib interface
-add_library(ft_irc_lib STATIC src/entity/Channel.cpp src/entity/Client.cpp src/handler/EventHandler.cpp src/core/Server.cpp src/core/Socket.cpp src/controller/ChannelController.cpp src/controller/ClientController.cpp include/controller/Executor.hpp src/controller/Executor.cpp src/core/Udata.cpp src/core/Parser.cpp src/core/utility.cpp include/handler/ResponseHandler.hpp src/handler/ErrorHandler.cpp include/handler/ResponseHandler.hpp src/handler/ResponseHandler.cpp)
+add_library(ft_irc_lib STATIC src/entity/Channel.cpp src/entity/Client.cpp src/handler/EventHandler.cpp src/core/Server.cpp src/core/Socket.cpp src/controller/ChannelController.cpp src/controller/ClientController.cpp include/controller/Executor.hpp src/controller/Executor.cpp src/core/Parser.cpp src/core/utility.cpp include/handler/ResponseHandler.hpp src/handler/ErrorHandler.cpp include/handler/ResponseHandler.hpp src/handler/ResponseHandler.cpp src/core/Command.cpp src/core/Command.cpp src/core/Command.cpp)
 # Include ft_irc hpp files
 target_include_directories(ft_irc_lib PUBLIC include)
 # Set ft_irc_lib compile option

--- a/src/core/Parser.cpp
+++ b/src/core/Parser.cpp
@@ -57,9 +57,9 @@ std::string &Parser::validNickName(std::string &nickname) {
 void Parser::parseQuit(e_cmd &cmd, params *&params) {
     cmd = QUIT;
     quit_params *p;
-    if (getToken(MSG)) {
+    if (getToken(MSG) && token[0] == ':') {
         p = new quit_params;
-        p->msg = token;
+        p->msg = "\"" + token.substr(1) + "\"";;
     }
     params = p;
 }
@@ -190,8 +190,8 @@ void Parser::parseKick(e_cmd &cmd, params *&params) {
         p->channel = validChannelName(token);
         if (!isEOF() && getToken()) {
             p->user = token;
-            if (getToken(MSG) != EOF) {
-                p->comment = token;
+            if (getToken(MSG) != EOF && token[0] == ':') {
+                p->comment = "\"" + token.substr(1) + "\"";;
             }
         } else {
             delete p;
@@ -226,8 +226,8 @@ void Parser::parsePrivmsg(e_cmd &cmd, params *&params) {
         p = new privmsg_params;
         std::vector<std::string> receivers = split(token, ',');
         p->receivers = receivers;
-        if (!isEOF() && getToken(MSG)) {
-            p->msg = token;
+        if (!isEOF() && getToken(MSG) && token[0] == ':') {
+            p->msg = "\"" + token.substr(1) + "\"";
         } else {
             delete p;
             throw NotEnoughParamsException("PRIVMSG");
@@ -244,8 +244,8 @@ void Parser::parseNotice(e_cmd &cmd, params *&params) {
     if (!isEOF() && getToken()) {
         p = new notice_params;
         p->nickname = token;
-        if (!isEOF() && getToken(MSG)) {
-            p->msg = token;
+        if (!isEOF() && getToken(MSG) && token[0] == ':') {
+            p->msg = "\"" + token.substr(1) + "\"";;
         } else {
             delete p;
             throw NotEnoughParamsException("NOTICE");

--- a/src/handler/ResponseHandler.cpp
+++ b/src/handler/ResponseHandler.cpp
@@ -26,7 +26,7 @@ void ResponseHandler::handleResponse(ConnectSocket *src,
     std::string msg = getMessage(res_code);
 
     res_stream << ":" << servername << " " << res_code << " "
-               << src->getNickname() << " " << command << ":\"" << msg << "\""
+               << src->getNickname() << " " << command << ":" << msg
                << std::endl;
     res = res_stream.str();
     src->send_buf.append(res);
@@ -77,7 +77,7 @@ std::string ResponseHandler::createResponse(ConnectSocket *src,
     if (msg.empty())
         res_stream << " :" << param << std::endl;
     else
-        res_stream << " " << param << " :\"" << msg << "\"" << std::endl;
+        res_stream << " " << param << " :" << msg << std::endl;
     return res_stream.str();
     // src->send_buf.append(res);
 }
@@ -123,7 +123,7 @@ std::string ResponseHandler::getMessage(e_res_code res_code) {
 
 void ResponseHandler::handleConnectResponse(ConnectSocket *src) {
     const std::string prefix = src->getNickname() + "!" + src->getUsername() +
-                               "@" + src->getHostname();
+        "@" + src->getHostname();
     // TODO date
     std::string res_comment[4] = {prefix, "", "", "eyeRsee.local 1.0 o oit"};
     for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
# Msg parse Error

## 개요
- 기존에 `:msg` 로 들어오는 걸 `"msg"` 로 변환해서 파싱
- ResponseHandler 에 있는 따옴표 제거

## 작업내용
- 기존에 `:msg` 로 들어오는 걸 `"msg"` 로 변환해서 파싱
- ResponseHandler 에 있는 따옴표 제거

## 주의사항