### PR TITLE
[BugFix] quit, add updateClient status

### DIFF
--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -44,7 +44,7 @@ class ClientController {
     void erase(const std::string& nickname);
     void erase(int fd);
 
-    int updateClient(int fd, Client* client, e_status status);
+    int udatateClientStatus(int fd, Client* client, e_status status);
 
     void updateNickname(int fd, const std::string& nickname);
     void updateNickname(Client* client, const std::string& nickname);

--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <utility>
 
+#include "core/Type.hpp"
+
 namespace ft {
 
 class Client;
@@ -41,6 +43,8 @@ class ClientController {
     void erase(const Client* client);
     void erase(const std::string& nickname);
     void erase(int fd);
+
+    int updateClient(int fd, Client* client, e_status status);
 
     void updateNickname(int fd, const std::string& nickname);
     void updateNickname(Client* client, const std::string& nickname);

--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -44,9 +44,9 @@ class ClientController {
     void erase(const std::string& nickname);
     void erase(int fd);
 
-    int updateClientStatus(int fd, Client* client, e_status status);
+    void updateClientStatus(int fd, Client* client, e_status status);
 
-    void updateNickname(int fd, const std::string& nickname);
+    //void updateNickname(int fd, const std::string& nickname);
     void updateNickname(Client* client, const std::string& nickname);
 
     void insertChannel(Client* client, Channel* channel);

--- a/include/controller/ClientController.hpp
+++ b/include/controller/ClientController.hpp
@@ -44,7 +44,7 @@ class ClientController {
     void erase(const std::string& nickname);
     void erase(int fd);
 
-    int udatateClientStatus(int fd, Client* client, e_status status);
+    int updateClientStatus(int fd, Client* client, e_status status);
 
     void updateNickname(int fd, const std::string& nickname);
     void updateNickname(Client* client, const std::string& nickname);

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -37,6 +37,8 @@ class Executor {
     void connect(Command *command, Client *client, std::string password);
     void execute(Command *command, Client *client);
     Channel *createChannel(std::string channel_name);
+
+    int updateClient(int fd, Client *client, e_status status);
     void deleteClient(Client *client);
 
    private:

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -34,7 +34,7 @@ class Executor {
     void clearClientList();
 
     Client *accept(int fd);
-    void connect(Command *command, Client *client, std::string password);
+    int connect(Client *client, std::string password);
     void execute(Command *command, Client *client);
     Channel *createChannel(std::string channel_name);
 

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -38,7 +38,7 @@ class Executor {
     void execute(Command *command, Client *client);
     Channel *createChannel(std::string channel_name);
 
-    int udatateClientStatus(int fd, Client *client, e_status status);
+    int updateClientStatus(int fd, Client *client, e_status status);
     void deleteClient(Client *client);
 
    private:

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -38,7 +38,7 @@ class Executor {
     void execute(Command *command, Client *client);
     Channel *createChannel(std::string channel_name);
 
-    int updateClient(int fd, Client *client, e_status status);
+    int udatateClientStatus(int fd, Client *client, e_status status);
     void deleteClient(Client *client);
 
    private:

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -48,6 +48,7 @@ class Server : public EventHandler {
     void handleClose();
 
     int parse(int fd, Client *client);
+    int connect(int fd, Client *client);
     int response(int fd, std::string &send_buf);
 };
 

--- a/include/core/Socket.hpp
+++ b/include/core/Socket.hpp
@@ -42,8 +42,12 @@ class ConnectSocket : public SocketBase {
     std::string recv_buf;
     std::string send_buf;
 
-    e_status status;
     bool auth[3];
+
+    std::queue<Command *> commands;
+
+   protected:
+    e_status _status;
 
     std::string _nickname;
     std::string _username;
@@ -51,9 +55,6 @@ class ConnectSocket : public SocketBase {
     std::string _servername;
     std::string _realname;
 
-    std::queue<Command *> commands;
-
-   protected:
    public:
     ConnectSocket();
     ConnectSocket(const ConnectSocket &copy);
@@ -64,6 +65,7 @@ class ConnectSocket : public SocketBase {
     void createSocket(const int &listen_fd);
 
     // getter
+    e_status getStatus() const;
     const std::string &getNickname() const;
     const std::string &getUsername() const;
     const std::string &getHostname() const;
@@ -71,6 +73,8 @@ class ConnectSocket : public SocketBase {
     const std::string &getRealname() const;
 
     // setter
+    void setStatus(e_status status);
+    // TODO : setAuth
     void setNickname(const std::string &nickname);
     void setUsername(const std::string &username);
     void setHostname(const std::string &hostname);

--- a/include/core/Type.hpp
+++ b/include/core/Type.hpp
@@ -4,7 +4,7 @@
 namespace ft {
 enum e_event { ACCEPT, READ, EXECUTE, TIMER, D_WRITE, D_TIMER, IDLE };
 
-enum e_status { UNREGISTER, REGISTER };
+enum e_status { UNREGISTER, REGISTER, TIMEOUT, TERMINATE };
 
 enum e_cmd {
     PASS,

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -103,15 +103,9 @@ void ClientController::erase(int fd) {
     }
 }
 
-int ClientController::updateClientStatus(int fd, Client *client,
+void ClientController::updateClientStatus(int fd, Client *client,
                                          e_status status) {
-    Client *target = find(fd);
-
-    if (!target || target != client) return -1;
-    if (status == TIMEOUT && client->getStatus() != UNREGISTER) return -1;
-    if (status == REGISTER && client->isAuthenticate() == false) return -1;
     client->setStatus(status);
-    return 0;
 }
 
 /**
@@ -120,19 +114,19 @@ int ClientController::updateClientStatus(int fd, Client *client,
  * @param fd
  * @param nickname
  */
-void ClientController::updateNickname(int fd, const std::string &nickname) {
-    Client *client = find(fd);
+//void ClientController::updateNickname(int fd, const std::string &nickname) {
+//    Client *client = find(fd);
 
-    if (client) {  // valid
-        if (find(nickname)) {
-            // no change (already exist)
-        } else {
-            // change nickname
-            client->setNickname(nickname);
-        }
-    }
-    // TODO error handling (잘못된 fd일 경우)
-}
+//    if (client) {  // valid
+//        if (find(nickname)) {
+//            // no change (already exist)
+//        } else {
+//            // change nickname
+//            client->setNickname(nickname);
+//        }
+//    }
+//    // TODO error handling (잘못된 fd일 경우)
+//}
 
 void ClientController::updateNickname(Client *client,
                                       const std::string &nickname) {

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -103,12 +103,13 @@ void ClientController::erase(int fd) {
     }
 }
 
-int ClientController::udatateClientStatus(int fd, Client *client,
-                                          e_status status) {
+int ClientController::updateClientStatus(int fd, Client *client,
+                                         e_status status) {
     Client *target = find(fd);
 
     if (!target || target != client) return -1;
-    if (status == TIMEOUT && client->getStatus() == REGISTER) return -1;
+    if (status == TIMEOUT && client->getStatus() != UNREGISTER) return -1;
+    if (status == REGISTER && client->isAuthenticate() == false) return -1;
     client->setStatus(status);
     return 0;
 }

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -103,14 +103,12 @@ void ClientController::erase(int fd) {
     }
 }
 
-int ClientController::updateClient(int fd, Client *client, e_status status) {
-    if (status == REGISTER) {
-        if (!find(fd)) return -1;
-    } else if (status == TIMEOUT) {
-        Client *target = find(fd);
-        if (!target || target != client || client->getStatus() == REGISTER)
-            return -1;
-    }
+int ClientController::udatateClientStatus(int fd, Client *client,
+                                          e_status status) {
+    Client *target = find(fd);
+
+    if (!target || target != client) return -1;
+    if (status == TIMEOUT && client->getStatus() == REGISTER) return -1;
     client->setStatus(status);
     return 0;
 }

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -103,6 +103,18 @@ void ClientController::erase(int fd) {
     }
 }
 
+int ClientController::updateClient(int fd, Client *client, e_status status) {
+    if (status == REGISTER) {
+        if (!find(fd)) return -1;
+    } else if (status == TIMEOUT) {
+        Client *target = find(fd);
+        if (!target || target != client || client->getStatus() == REGISTER)
+            return -1;
+    }
+    client->setStatus(status);
+    return 0;
+}
+
 /**
  * @brief update nickname
  *

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -26,9 +26,9 @@ const std::set<Client *> &Executor::getClientList() const {
 }
 void Executor::clearClientList() { _client_list.clear(); }
 
-int Executor::updateClient(int fd, Client *client, e_status status) {
+int Executor::udatateClientStatus(int fd, Client *client, e_status status) {
     // TODO : refactor, isAthenticate
-    return (client_controller.updateClient(fd, client, status));
+    return (client_controller.udatateClientStatus(fd, client, status));
 }
 
 void Executor::deleteClient(Client *client) {
@@ -384,7 +384,7 @@ void Executor::quit(Client *client, params *params) {
 
     // 모든 채널에서 quit && send message
     broadcast(client->getChannelList(), response_msg);
-    client_controller.updateClient(client->getFd(), client, TERMINATE);
+    client_controller.udatateClientStatus(client->getFd(), client, TERMINATE);
 }
 
 void Executor::kick(Client *kicker, params *params) {

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -26,6 +26,11 @@ const std::set<Client *> &Executor::getClientList() const {
 }
 void Executor::clearClientList() { _client_list.clear(); }
 
+int Executor::updateClient(int fd, Client *client, e_status status) {
+    // TODO : refactor, isAthenticate
+    return (client_controller.updateClient(fd, client, status));
+}
+
 void Executor::deleteClient(Client *client) {
     ChannelController::ChannelList channel_list;
 
@@ -379,9 +384,7 @@ void Executor::quit(Client *client, params *params) {
 
     // 모든 채널에서 quit && send message
     broadcast(client->getChannelList(), response_msg);
-    client_controller.erase(client);
-    client_controller.findInSet(channel_list, client);
-    channel_controller.eraseClient(channel_list, client);
+    client_controller.updateClient(client->getFd(), client, TERMINATE);
 }
 
 void Executor::kick(Client *kicker, params *params) {

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -26,9 +26,8 @@ const std::set<Client *> &Executor::getClientList() const {
 }
 void Executor::clearClientList() { _client_list.clear(); }
 
-int Executor::udatateClientStatus(int fd, Client *client, e_status status) {
-    // TODO : refactor, isAthenticate
-    return (client_controller.udatateClientStatus(fd, client, status));
+int Executor::updateClientStatus(int fd, Client *client, e_status status) {
+    return (client_controller.updateClientStatus(fd, client, status));
 }
 
 void Executor::deleteClient(Client *client) {
@@ -384,7 +383,8 @@ void Executor::quit(Client *client, params *params) {
 
     // 모든 채널에서 quit && send message
     broadcast(client->getChannelList(), response_msg);
-    client_controller.udatateClientStatus(client->getFd(), client, TERMINATE);
+    client_controller.updateClientStatus(client->getFd(), client, TERMINATE);
+    _client_list.insert(client);
 }
 
 void Executor::kick(Client *kicker, params *params) {

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -26,7 +26,7 @@ void Env::parse(int argc, char **argv) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     d_port = std::strtod(port_str.c_str(), &back);
-    if (*back || d_port < 1025 | d_port > 65535) {
+    if (*back || d_port<1025 | d_port> 65535) {
         throw std::logic_error(
             "Error: arguments\n[hint] ./ft_irc <port(1025 ~ 65535)>");
     }
@@ -100,10 +100,9 @@ void Server::handleRead(int event_idx) {
     while (commands.size()) {
         _executor.connect(commands.front(), client, _env.password);
         commands.pop();
-        if (connect_socket->isAuthenticate()) {
+        if (_executor.udatateClientStatus(event.ident, client, REGISTER) == 0) {
             std::cout << "Register Success!" << std::endl;
             _tmp_garbage.erase(client);
-            _executor.updateClient(event.ident, client, REGISTER);
             ResponseHandler::handleConnectResponse(client);
             response(connect_socket->getFd(), connect_socket->send_buf);
             break;
@@ -132,7 +131,7 @@ void Server::handleExecute(int event_idx) {
     const std::set<Client *> &client_list = _executor.getClientList();
     std::set<Client *>::iterator receiver_iter = client_list.begin();
     for (; receiver_iter != client_list.end(); ++receiver_iter) {
-        if ((*receiver_iter)->getStatus() == TERMINATE){
+        if ((*receiver_iter)->getStatus() == TERMINATE) {
             _tmp_garbage.erase(*receiver_iter);
             _garbage.insert(*receiver_iter);
         } else
@@ -152,7 +151,7 @@ void Server::handleTimer(int event_idx) {
         static_cast<Client *>(event.udata);  // TODO : connect socket
 
     registerEvent(event.ident, EVFILT_TIMER, D_TIMER, 0);
-    if (_executor.updateClient(event.ident, client, TIMEOUT) == 0)
+    if (_executor.udatateClientStatus(event.ident, client, TIMEOUT) == 0)
         _tmp_garbage.insert(client);
 }
 void Server::handleTimeout() {

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -55,16 +55,16 @@ void ListenSocket::createSocket(const int &port) {
     sin.sin_port = htons(port);
     int i = 0;
     // 임시
-    //    while (bind(_fd, (struct sockaddr *) &sin, sizeof(sin)) < 0) {
-    //        sin.sin_port = htons(port + ++i);
-    //    }
-    //    std::cout << "listening port : " << port + i << std::endl;
+    while (bind(_fd, (struct sockaddr *) &sin, sizeof(sin)) < 0) {
+        sin.sin_port = htons(port + ++i);
+    }
+    std::cout << "listening port : " << port + i << std::endl;
 
-    if (bind(_fd, (struct sockaddr *) &sin, sizeof(sin)) < 0)
-        throw std::logic_error("bind error");
+    //if (bind(_fd, (struct sockaddr *)&sin, sizeof(sin)) < 0)
+    //    throw std::logic_error("bind error");
     if (listen(_fd, 42) < 0) throw std::logic_error("listen error");
 
-    setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, NULL, 0);
+    // setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, NULL, 0);
     setNonBlock();
 }
 
@@ -72,9 +72,12 @@ void ListenSocket::createSocket(const int &port) {
 /*                  ConnectSocket                   */
 /****************************************************/
 
-ConnectSocket::ConnectSocket() : SocketBase(-1), status(UNREGISTER) {
+ConnectSocket::ConnectSocket() : SocketBase(-1), _status(UNREGISTER) {
     recv_buf.reserve(512);
     send_buf.reserve(512);
+    auth[PASS] = false;
+    auth[USER] = false;
+    auth[NICK] = false;
 }
 ConnectSocket::ConnectSocket(const ConnectSocket &copy)
     : SocketBase(copy.getFd()) {}
@@ -87,8 +90,8 @@ void ConnectSocket::createSocket(const int &listen_fd) {
     struct sockaddr_in in = {};
     socklen_t in_len = sizeof(in);
 
-    _fd = accept(listen_fd, (struct sockaddr *) &in, &in_len);
-    status = UNREGISTER;
+    _fd = accept(listen_fd, (struct sockaddr *)&in, &in_len);
+    _status = UNREGISTER;
     auth[PASS] = false;
     auth[USER] = false;
     auth[NICK] = false;
@@ -100,6 +103,7 @@ void ConnectSocket::createSocket(const int &listen_fd) {
 }
 
 // getter
+e_status ConnectSocket::getStatus() const { return _status; }
 const std::string &ConnectSocket::getNickname() const { return _nickname; }
 const std::string &ConnectSocket::getUsername() const { return _username; }
 const std::string &ConnectSocket::getHostname() const { return _hostname; }
@@ -107,6 +111,8 @@ const std::string &ConnectSocket::getServername() const { return _servername; }
 const std::string &ConnectSocket::getRealname() const { return _realname; }
 
 // setter
+void ConnectSocket::setStatus(e_status status) { _status = status; }
+
 void ConnectSocket::setNickname(const std::string &nickname) {
     _nickname = nickname;
 }
@@ -116,7 +122,9 @@ void ConnectSocket::setUsername(const std::string &username) {
 void ConnectSocket::setHostname(const std::string &hostname) {
     _hostname = hostname;
 }
-void ConnectSocket::setServername(const std::string &servername) { _servername = servername; }
+void ConnectSocket::setServername(const std::string &server) {
+    _servername = server;
+}
 void ConnectSocket::setRealname(const std::string &realname) {
     _realname = realname;
 }

--- a/src/entity/Client.cpp
+++ b/src/entity/Client.cpp
@@ -1,7 +1,7 @@
 #include "entity/Client.hpp"
 
 namespace ft {
-Client::Client() {}
+Client::Client() : ConnectSocket() {}
 
 Client::Client(const Client &copy) { *this = copy; }
 


### PR DESCRIPTION
## 개요
- quit
## 작업내용
- updateClientStatus : ConnectSocket 에 _status 값을 상황에 따라 update해줌
  - <client의 state> ->  <바꿀 status>
    - UNREGISTER -> REGISTER
      - isAuthenticate() 를 사용해서, update가 가능한지 확인함
        - pass, user, nick 이 확인 됐으면 true 반환
        - 하나라도 미확인이면 false를 반환
    - ??? -> TIMEOUT
      - 이미 REGISTER 되었을 수도 있고, TERMINATE 상태일 수 있음
      - 현재상태(getStatus한 값)이 UNREGISTER 일 때만 update 해줘야 함

## 주의사항
- ClientController::_clients, 를 _client 와 _unregisters 로 나누려 했으나 실패~!
  - _tmp_garbage 도 지우려 했으나 실패
  - map<int, Client*> 였으면 척척 풀렸을듯
- [Question 1] _status  값을 상황에 따라 update 해준댔는데 잘못된 방법이란 생각이 듭니다.
  1. 어차피 set 함수로 바꾸는 건데, 괜히 update 라는 함수들을 끼워버렸는가? 
  2. if문으로 상황에 따라 set 할지 말지를 결정하는 함수는 update 가 아니라 다른 이름을 가져야 하는가?
  3. if문으로 set할지 말지를 결정하는 부분은 어느 객체가 수행해야 하는가?
    - Server::handleRead
    - Executor::updateClientState
    - ClientController::updateClientState