### PR TITLE
[BugFix] Fix topic parse error

### DIFF
--- a/include/controller/BotController.hpp
+++ b/include/controller/BotController.hpp
@@ -1,0 +1,12 @@
+#ifndef BOTCONTROLLER_HPP
+#define BOTCONTROLLER_HPP
+
+namespace ft {
+
+class BotController {
+    
+};
+
+}
+
+#endif //BOTCONTROLLER_HPP

--- a/src/core/Parser.cpp
+++ b/src/core/Parser.cpp
@@ -213,15 +213,15 @@ void Parser::parseTopic(e_cmd &cmd, params *&params) {
     cmd = TOPIC;
     topic_params *p;
 
-    std::vector<std::string> tokens = split(tokenStream, ' ');
-    if (!(tokens.size() == 1 || tokens.size() == 2)) {
-        throw NotEnoughParamsException("TOPIC");
-    }
-    p = new topic_params;
-
-    p->channel = validChannelName(tokens[0]);
-    if (tokens.size() == 2) {
-        p->topic = tokens[1];
+    if (!isEOF() && getToken()) {
+        p = new topic_params;
+        p->channel = validChannelName(token);
+        if (!isEOF() && getToken(MSG) && token[0] == ':') {
+            p->topic = token.substr(1);
+        } else {
+            delete p;
+            throw NotEnoughParamsException("TOPIC");
+        }
     }
     params = p;
 }


### PR DESCRIPTION
# Fix topic parse error

## 개요
<img width="663" alt="image" src="https://user-images.githubusercontent.com/51353146/227461645-5d7f7d0e-6388-4968-a3db-8713b5a3276d.png">
<img width="654" alt="image" src="https://user-images.githubusercontent.com/51353146/227461974-dd05408e-fb9d-48c6-83d1-278e990e9ecc.png">


## 작업내용
- topic msg SPACE 허용
- topic msg `:` 제거

## 주의사항