### PR TITLE
[Refactor] 1.0.2

### DIFF
--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -35,6 +35,7 @@ class Executor {
 
     Client *accept(int fd);
     int connect(Client *client, std::string password);
+    void execute(Command *command, Client *client, std::string password);
     void execute(Command *command, Client *client);
     Channel *createChannel(std::string channel_name);
 

--- a/include/controller/Executor.hpp
+++ b/include/controller/Executor.hpp
@@ -34,7 +34,7 @@ class Executor {
     void clearClientList();
 
     Client *accept(int fd);
-    int connect(Client *client, std::string password);
+    bool connect(Client *client, std::string password);
     void execute(Command *command, Client *client, std::string password);
     void execute(Command *command, Client *client);
     Channel *createChannel(std::string channel_name);

--- a/include/core/Parser.hpp
+++ b/include/core/Parser.hpp
@@ -45,7 +45,7 @@ class Parser {
     void parsePing(e_cmd &cmd, params *&params);
 
     Command *parse(const std::string &command_line, Command *&command);
-    std::queue<Command *> parse(ConnectSocket *src);
+    void parse(ConnectSocket *src);
 
     class SyntaxException : public std::exception {
        protected:
@@ -60,26 +60,27 @@ class Parser {
     class UnknownCommandException : public SyntaxException {
        public:
         UnknownCommandException(const std::string &cause)
-            : SyntaxException(cause) {};
+            : SyntaxException(cause){};
     };
     class NotEnoughParamsException : public SyntaxException {
        public:
         NotEnoughParamsException(const std::string &cause)
-            : SyntaxException(cause) {};
+            : SyntaxException(cause){};
     };
     class InvalidChannelNameException : public SyntaxException {
        public:
         InvalidChannelNameException(const std::string &cause)
-            : SyntaxException(cause) {};
+            : SyntaxException(cause){};
     };
     class InvalidNickNameException : public SyntaxException {
        public:
         InvalidNickNameException(const std::string &cause)
-            : SyntaxException(cause) {};
+            : SyntaxException(cause){};
     };
     class UnHandledModeException : public SyntaxException {
        public:
-        UnHandledModeException(const std::string &cause) : SyntaxException(cause) {};
+        UnHandledModeException(const std::string &cause)
+            : SyntaxException(cause){};
     };
 };
 

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -48,7 +48,7 @@ class Server : public EventHandler {
 
    private:
     int parse(int fd, Client *client);
-    int connect(int fd, Client *client);
+    void connect(int fd, Client *client);
     void reserve();
     int response(int fd, std::string &send_buf);
 

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -51,6 +51,8 @@ class Server : public EventHandler {
     int connect(int fd, Client *client);
     void reserve();
     int response(int fd, std::string &send_buf);
+
+    void destroyCommands(std::queue<Command *> &commands);
 };
 
 }  // namespace ft

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -46,8 +46,10 @@ class Server : public EventHandler {
     // garbageCollector methods
     void handleClose();
 
+   private:
     int parse(int fd, Client *client);
     int connect(int fd, Client *client);
+    void reserve();
     int response(int fd, std::string &send_buf);
 };
 

--- a/include/core/Server.hpp
+++ b/include/core/Server.hpp
@@ -44,7 +44,6 @@ class Server : public EventHandler {
     void handleTimer(int event_idx);
 
     // garbageCollector methods
-    void handleTimeout();
     void handleClose();
 
     int parse(int fd, Client *client);

--- a/include/handler/EventHandler.hpp
+++ b/include/handler/EventHandler.hpp
@@ -24,7 +24,6 @@ class EventHandler {
     Event _ev_list[_max_event];
     EventList _change_list;
 
-    std::set<Client *> _tmp_garbage;  // timeout
     std::set<Client *> _garbage;      // client gone
 
    public:
@@ -37,7 +36,6 @@ class EventHandler {
     int monitorEvent();
 
     void garbageCollector();           // TODO : naming;
-    virtual void handleTimeout() = 0;  // TODO : naming;
     virtual void handleClose() = 0;    // TODO : naming;
 
     // handle functions

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -53,17 +53,17 @@ Client *Executor::accept(int fd) {
     return new_client;
 }
 
-int Executor::connect(Client *client, std::string password) {
+bool Executor::connect(Client *client, std::string password) {
     std::queue<Command *> &commands = client->commands;
     while (commands.size()) {
         execute(commands.front(), client, password);
         commands.pop();
         if (client->isAuthenticate()) {
             updateClientStatus(client->getFd(), client, REGISTER);
-            return 0;
+            return true;
         }
     }
-    return 1;
+    return false;
 }
 
 void Executor::execute(Command *command, Client *client, std::string password) {

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -165,7 +165,8 @@ void Executor::join(Client *client, params *params) {
         if (channel == NULL) {  // new channel & operator Client
             channel = channel_controller.insert(*iter);
             channel_controller.insertOperator(channel, client);
-            channel_controller.updateMode(TOPIC_PRIV_T, channel);
+        } else if (channel_controller.isOnChannel(channel, client)) {
+            return;
         } else {  // regular Client
             channel_controller.insertRegular(channel, client);
         }

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -398,9 +398,9 @@ void Executor::quit(Client *client, params *params) {
     response_msg = ResponseHandler::createResponse(client, "QUIT", msg);
 
     // 모든 채널에서 quit && send message
+    _client_list.insert(client);
     broadcast(client->getChannelList(), response_msg);
     client_controller.updateClientStatus(client->getFd(), client, TERMINATE);
-    _client_list.insert(client);
 }
 
 void Executor::kick(Client *kicker, params *params) {
@@ -499,8 +499,8 @@ void Executor::broadcast(Channel *channel, const std::string &msg,
     iter = receivers.begin();
     for (; iter != receivers.end(); ++iter) {
         (*iter)->send_buf.append(msg);
-        _client_list.insert(*iter);
     }
+    _client_list.insert(receivers.begin(), receivers.end());
 }
 
 /**
@@ -518,8 +518,8 @@ void Executor::broadcast(const ChannelList &channel_list,
     client_iter = client_list.begin();
     for (; client_iter != client_list.end(); ++client_iter) {
         (*client_iter)->send_buf.append(msg);
-        _client_list.insert(*client_iter);
     }
+    _client_list.insert(channel_list.begin(), channel_list.end());
 }
 
 void Executor::notice(Client *client, params *params) {

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -84,6 +84,7 @@ void Executor::execute(Command *command, Client *client, std::string password) {
                  0);
             break;
     }
+    delete command;
 }
 
 void Executor::execute(Command *command, Client *client) {
@@ -124,6 +125,7 @@ void Executor::execute(Command *command, Client *client) {
         default:
             break;
     }
+    delete command;
 }
 
 /**

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -519,7 +519,7 @@ void Executor::broadcast(const ChannelList &channel_list,
     for (; client_iter != client_list.end(); ++client_iter) {
         (*client_iter)->send_buf.append(msg);
     }
-    _client_list.insert(channel_list.begin(), channel_list.end());
+    _client_list.insert(client_list.begin(), client_list.end());
 }
 
 void Executor::notice(Client *client, params *params) {

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -54,7 +54,7 @@ Client *Executor::accept(int fd) {
 }
 
 int Executor::connect(Client *client, std::string password) {
-    std::queue<Command *> commands = client->commands;
+    std::queue<Command *> &commands = client->commands;
     while (commands.size()) {
         execute(commands.front(), client, password);
         commands.pop();

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -329,10 +329,6 @@ void Executor::pass(Client *new_client, params *params,
 
 void Executor::user(Client *new_client, params *params) {
     user_params *param = dynamic_cast<user_params *>(params);
-    std::string username = param->username;
-    std::string hostname = param->hostname;
-    std::string servername = param->servername;
-    std::string realname = param->realname;
 
     if (new_client->auth[USER]) {
         // 462 abc :You may not reregister.
@@ -340,10 +336,10 @@ void Executor::user(Client *new_client, params *params) {
                                   ERR_ALREADYREGISTERED);
         return;
     }
-    new_client->setUsername(username);
-    new_client->setHostname(hostname);
-    new_client->setServername(servername);
-    new_client->setRealname(realname);
+    new_client->setUsername(param->username);
+    new_client->setHostname(param->hostname);
+    new_client->setServername(param->servername);
+    new_client->setRealname(param->realname);
     new_client->auth[USER] = true;
     // response
     // USER guest tolmoon tolsun :Ronnie Reagan

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -56,31 +56,34 @@ Client *Executor::accept(int fd) {
 int Executor::connect(Client *client, std::string password) {
     std::queue<Command *> commands = client->commands;
     while (commands.size()) {
-        Command *command = commands.front();
+        execute(commands.front(), client, password);
         commands.pop();
-        switch (command->type) {
-            case PASS:
-                pass(client, command->params, password);
-                break;
-            case USER:
-                user(client, command->params);
-                break;
-            case NICK:
-                nick(client, command->params);
-                break;
-            default:
-                // TODO : msg
-                send(client->getFd(),
-                     ":eyeRsee.local 451 * JOIN :You have not registered.\n",
-                     53, 0);
-                break;
-        }
         if (client->isAuthenticate()) {
             updateClientStatus(client->getFd(), client, REGISTER);
             return 0;
         }
     }
     return 1;
+}
+
+void Executor::execute(Command *command, Client *client, std::string password) {
+    switch (command->type) {
+        case PASS:
+            pass(client, command->params, password);
+            break;
+        case USER:
+            user(client, command->params);
+            break;
+        case NICK:
+            nick(client, command->params);
+            break;
+        default:
+            // TODO : msg
+            send(client->getFd(),
+                 ":eyeRsee.local 451 * JOIN :You have not registered.\n", 53,
+                 0);
+            break;
+    }
 }
 
 void Executor::execute(Command *command, Client *client) {

--- a/src/core/Parser.cpp
+++ b/src/core/Parser.cpp
@@ -316,9 +316,9 @@ Command *Parser::parse(const std::string &command_line, Command *&command) {
     }
     return command;
 }
-std::queue<Command *> Parser::parse(ConnectSocket *src) {
+void Parser::parse(ConnectSocket *src) {
     std::string line;
-    std::queue<Command *> commands;
+    std::queue<Command *> &commands = src->commands;
     std::vector<std::string> command_lines;
 
     line = src->readRecvBuf();
@@ -339,7 +339,6 @@ std::queue<Command *> Parser::parse(ConnectSocket *src) {
             ErrorHandler::handleError(e, src);
         }
     }
-    return commands;
 }
 
 Parser::SyntaxException::SyntaxException(const std::string &cause)

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -116,7 +116,7 @@ void Server::handleExecute(int event_idx) {
     ConnectSocket *connect_socket = static_cast<ConnectSocket *>(client);
     std::queue<Command *> &commands = connect_socket->commands;
 
-    while (commands.size()) {
+    if (commands.size()) {
         _executor.execute(commands.front(), client);
         commands.pop();
     }
@@ -132,7 +132,8 @@ void Server::handleExecute(int event_idx) {
     }
     _executor.clearClientList();
 
-    if (response(event.ident, connect_socket->send_buf) == 0)
+    if (response(event.ident, connect_socket->send_buf) == 0 &&
+        commands.size() == 0)
         registerEvent(event.ident, EVFILT_WRITE, D_WRITE, 0);
 }
 

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -166,7 +166,7 @@ int Server::parse(int fd, Client *client) {
     client->recv_buf.append(buf);
 
     // parse commandlines in connect_sockets
-    client->commands = _parser.parse(client);
+    _parser.parse(client);
     return (client->commands.size());
 }
 

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -101,8 +101,7 @@ void Server::handleRead(int event_idx) {
             connect(event.ident, client);
             break;
         default:
-            std::queue<Command *> empty;
-            std::swap(client->commands, empty);
+            destroyCommands(client->commands);
             break;
     }
 }
@@ -211,6 +210,14 @@ int Server::response(int fd, std::string &send_buf) {
     else
         std::cerr << "[UB] send return -1" << std::endl;
     return -1;
+}
+
+void Server::destroyCommands(std::queue<Command *> &commands){
+    while (commands.size())
+    {
+        delete commands.front();
+        commands.pop();
+    }
 }
 
 }  // namespace ft

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -124,10 +124,9 @@ void Server::handleExecute(int event_idx) {
     const std::set<Client *> &client_list = _executor.getClientList();
     std::set<Client *>::iterator receiver_iter = client_list.begin();
     for (; receiver_iter != client_list.end(); ++receiver_iter) {
-        if ((*receiver_iter)->getStatus() == TERMINATE) {
-            _tmp_garbage.erase(*receiver_iter);
+        if ((*receiver_iter)->getStatus() == TERMINATE)
             _garbage.insert(*receiver_iter);
-        } else
+        else
             registerEvent((*receiver_iter)->getFd(), EVFILT_WRITE, EXECUTE,
                           *receiver_iter);
     }
@@ -143,19 +142,9 @@ void Server::handleTimer(int event_idx) {
         static_cast<Client *>(event.udata);  // TODO : connect socket
 
     registerEvent(event.ident, EVFILT_TIMER, D_TIMER, 0);
-    if (_executor.updateClientStatus(event.ident, client, TIMEOUT) == 0)
-        _tmp_garbage.insert(client);
-}
-void Server::handleTimeout() {
-    std::set<Client *>::iterator iter = _tmp_garbage.begin();
-
-    for (; iter != _tmp_garbage.end(); ++iter) {
-        _garbage.insert(*iter);
-        send((*iter)->getFd(), "Timeout\n", 9, 0);
-    }
-    iter = _garbage.begin();
-    for (; iter != _garbage.end(); ++iter) {
-        _tmp_garbage.erase(*iter);
+    if (_executor.updateClientStatus(event.ident, client, TIMEOUT) == 0){
+        _garbage.insert(client);
+        send(client->getFd(), "Timeout\n", 9, 0);
     }
 }
 

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -169,10 +169,10 @@ int Server::parse(int fd, Client *client) {
     return (client->commands.size());
 }
 
-int Server::connect(int fd, Client *client) {
+void Server::connect(int fd, Client *client) {
     std::queue<Command *> &commands = client->commands;
 
-    if (_executor.connect(client, _env.password) == 0) {
+    if (_executor.connect(client, _env.password) == true) {
         std::cout << "Register Success!" << std::endl;
         ResponseHandler::handleConnectResponse(client);
         response(fd, client->send_buf);
@@ -182,7 +182,6 @@ int Server::connect(int fd, Client *client) {
     if (client->send_buf.length()) {
         response(client->getFd(), client->send_buf);
     }
-    return 0;
 }
 
 void Server::reserve() {

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -30,7 +30,6 @@ int EventHandler::monitorEvent() {
 }
 
 void EventHandler::garbageCollector() {
-    handleTimeout();
     handleClose();
 }
 
@@ -51,7 +50,6 @@ void EventHandler::handleEvent(int event_idx) {
         action = TIMER;
 
     if (event.flags & EV_EOF) {
-        _tmp_garbage.erase(client);
         _garbage.insert(client);
         std::cout << "# " << event.ident << " EOF" << std::endl;
         return;


### PR DESCRIPTION
## 개요
- remove handleTimer
- add Server::connect
- Server::handleExecute 에서 loop 문으로 돌아가던 execute 단일 실행으로 변경
## 작업내용
- 기존의 PASS, USER, NICK command 를 실행하던, connect 는 execute 로 이름 변경
    - `void execute(Command *command, Client *client, std::string password);`
- set에 다른 set을 insert 하는 경우, iterator로 insert 하는 것으로 변경
## 주의사항
- main 말고 refactor/1.0 에 merge 하는게 나은가요?