### PR TITLE
[BugFix] INVITE, MODE 관련 에러 처리

### DIFF
--- a/include/handler/ResponseHandler.hpp
+++ b/include/handler/ResponseHandler.hpp
@@ -69,6 +69,10 @@ class ResponseHandler {
                                          std::vector<std::string> &operators,
                                          std::vector<std::string> &regulars);
 
+    static void handleInviteResponse(ConnectSocket *invitor,
+                                     ConnectSocket *target,
+                                     const std::string &channel_name);
+
     static void handleConnectResponse(ConnectSocket *src);
 
    private:

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -25,7 +25,6 @@ Channel *ChannelController::insert(const std::string &channel_name) {
     pair p = _channels.insert(std::make_pair(channel_name, Channel()));
     new_channel = &(p.first->second);
     new_channel->setName(channel_name);
-    new_channel->clearMode();
     return new_channel;
 }
 
@@ -144,15 +143,18 @@ void ChannelController::eraseClient(ChannelList &channel_list, Client *client) {
 }
 
 bool ChannelController::isInviteMode(const Channel *channel) {
-    return (channel->getMode() & (INVITE_ONLY_T - 1));
+    // return (channel->getMode() & (INVITE_ONLY_T - 1));
+    return (channel->getMode() & (1 << (INVITE_ONLY_T / 2)));
 }
 
 bool ChannelController::isTopicMode(const Channel *channel) {
-    return (channel->getMode() & (TOPIC_PRIV_T - 1));
+    // return (channel->getMode() & (TOPIC_PRIV_T - 1));
+    return (channel->getMode() & (1 << (TOPIC_PRIV_T / 2)));
 }
 
 bool ChannelController::isBanMode(const Channel *channel) {
-    return (channel->getMode() & (BAN_T - 1));
+    // return (channel->getMode() & (BAN_T - 1));
+    return (channel->getMode() & (1 << (BAN_T / 2)));
 }
 
 // private functions

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -1,14 +1,20 @@
 #include "entity/Channel.hpp"
 
+#include "core/Type.hpp"
+
 namespace ft {
 
-Channel::Channel() : _mode(0) {}
-Channel::Channel(const std::string &name) : _name(name), _mode(0) {}
-Channel::Channel(const Channel &copy) {
-    if (*this != copy) {
-        *this = copy;
-    }
+Channel::Channel() {
+    _mode = 0;
+    setMode(TOPIC_PRIV_T);
+    setMode(INVITE_ONLY_F);
 }
+Channel::Channel(const std::string &name) : _name(name) {
+    _mode = 0;
+    setMode(TOPIC_PRIV_T);
+    setMode(INVITE_ONLY_F);
+}
+Channel::Channel(const Channel &copy) { *this = copy; }
 Channel::~Channel() {}
 Channel &Channel::operator=(const Channel &ref) {
     _name = ref._name;
@@ -34,8 +40,6 @@ void Channel::setMode(int mode) {
     else
         _mode &= ~(1 << (mode / 2));  // -flag
 }
-
-void Channel::clearMode() { _mode = 0; }
 
 // update
 // void Channel::insertClient(Client *client, bool is_operator) {

--- a/src/handler/ErrorHandler.cpp
+++ b/src/handler/ErrorHandler.cpp
@@ -28,16 +28,16 @@ void ErrorHandler::handleError(ConnectSocket *src, std::string cause,
 }
 void ErrorHandler::handleError(std::exception &e, ConnectSocket *src) {
     if (Parser::UnknownCommandException *uce =
-        dynamic_cast<Parser::UnknownCommandException *>(&e))
+            dynamic_cast<Parser::UnknownCommandException *>(&e))
         handleError(src, uce->getCause(), ERR_UNKNOWNCOMMAND);
     else if (Parser::NotEnoughParamsException *nepe =
-        dynamic_cast<Parser::NotEnoughParamsException *>(&e))
+                 dynamic_cast<Parser::NotEnoughParamsException *>(&e))
         handleError(src, nepe->getCause(), ERR_NEEDMOREPARAMS);
     else if (Parser::InvalidChannelNameException *icne =
-        dynamic_cast<Parser::InvalidChannelNameException *>(&e))
+                 dynamic_cast<Parser::InvalidChannelNameException *>(&e))
         handleError(src, icne->getCause(), ERR_BADCHANMASK);
     else if (Parser::InvalidNickNameException *inne =
-        dynamic_cast<Parser::InvalidNickNameException *>(&e))
+                 dynamic_cast<Parser::InvalidNickNameException *>(&e))
         handleError(src, inne->getCause(), ERR_ERRONEUSNICKNAME);
     else
         std::cout << "ErrorHandler: Unknown error occurred" << std::endl;
@@ -99,7 +99,7 @@ const std::string ErrorHandler::ERR_USERONCHANNEL_MSG = "is already on channel";
 const std::string ErrorHandler::ERR_UNKNOWNMODE_MSG =
     "is unknown mode char to me";
 const std::string ErrorHandler::ERR_INVITEONLYCHAN_MSG =
-    "Cannot join channel (+i)";
+    "Cannot join channel (invite only)";
 const std::string ErrorHandler::ERR_CHANOPRIVSNEEDED_MSG =
     "You're not channel operator";
 const std::string ErrorHandler::ERR_NOSUCHNICK_MSG = "No such nick";

--- a/src/handler/ResponseHandler.cpp
+++ b/src/handler/ResponseHandler.cpp
@@ -111,6 +111,26 @@ std::string ResponseHandler::createJoinReponse(
     return res_stream.str();
 }
 
+void ResponseHandler::handleInviteResponse(ConnectSocket *invitor,
+                                           ConnectSocket *target,
+                                           const std::string &channel_name) {
+    std::stringstream invitor_res;
+    std::stringstream target_res;
+
+    invitor_res.fill('0');
+    target_res.fill('0');
+    // 341
+    invitor_res << invitor->getServername() << " " << RPL_INVITING << " "
+                << invitor->getNickname() << " " << target->getNickname()
+                << " :" << channel_name << std::endl;
+    invitor->send_buf.append(invitor_res.str());
+
+    target_res << ":" << invitor->getNickname() << "!" << invitor->getUsername()
+               << "@" << invitor->getServername() << " INVITE "
+               << target->getNickname() << " :" << channel_name << std::endl;
+    target->send_buf.append(target_res.str());
+}
+
 void ResponseHandler::handleConnectResponse(ConnectSocket *src) {
     const std::string prefix = src->getNickname() + "!" + src->getUsername() +
                                "@" + src->getHostname();


### PR DESCRIPTION
## 개요
- invite, mode 관련 에러 처리

## 작업내용
- `ResponseHandler::handleInviteResponse` 함수 추가
- mode 초기화하는 부분 기존 `clearMode`에서 생성자로 수정
- `isInviteMode` 같은 mode 확인하는 함수 잘못된 연산 수정
- `JOIN`에서 채널에 들어갈 때 `invite` mode 확인하는 로직 추가

## 주의사항
- 브랜치 분기를 깜빡하고 hotfix/topic에 push 했습니닷.. 