### PR TITLE
[BugFix] INVITE, MODE 관련 에러 처리

### DIFF
--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -50,6 +50,7 @@ class ChannelController {
 
     void insertOperator(Channel *channel, Client *client);
     void insertRegular(Channel *channel, Client *client);
+    void insertInvitedClient(Channel *channel, Client *client);
 
     void eraseClient(Channel *channel, Client *client);
     void eraseClient(ChannelList &channel_list, Client *client);

--- a/include/controller/ChannelController.hpp
+++ b/include/controller/ChannelController.hpp
@@ -54,6 +54,7 @@ class ChannelController {
 
     void eraseClient(Channel *channel, Client *client);
     void eraseClient(ChannelList &channel_list, Client *client);
+    void eraseInvitedClient(Channel *channel, Client *client);
 
     const std::set<Client *> &getOperators(const Channel *channel) const;
     const std::set<Client *> &getRegulars(const Channel *channel) const;
@@ -61,6 +62,7 @@ class ChannelController {
     bool isOnChannel(Channel *channel, Client *client);
     bool isOperator(Channel *channel, Client *client);
     bool isRegular(Channel *channel, Client *client);
+    bool isInvitedClient(Channel *channel, Client *client);
 
     bool isInviteMode(const Channel *channel);
     bool isTopicMode(const Channel *channel);

--- a/include/entity/Channel.hpp
+++ b/include/entity/Channel.hpp
@@ -22,11 +22,12 @@ class Channel {
     typedef std::set<Client *>::iterator client_list_iterator;
 
    private:
+    int _mode;
     std::string _name;
     std::string _topic;
     ClientList _regulars;
     ClientList _operators;
-    int _mode;
+    ClientList _invited_clients;  // invite list
 
    public:
     Channel();
@@ -50,6 +51,7 @@ class Channel {
     // update
     void insertOperator(Client *client);
     void insertRegular(Client *client);
+    void insertInvitedClient(Client *client);
 
     void eraseOperator(Client *client);
     void eraseRegular(Client *client);

--- a/include/entity/Channel.hpp
+++ b/include/entity/Channel.hpp
@@ -40,6 +40,7 @@ class Channel {
     const std::string &getTopic() const;
     const ClientList &getRegulars() const;
     const ClientList &getOperators() const;
+    const ClientList &getInvitedClients() const;
     int getMode() const;
 
     void setName(const std::string &name);
@@ -55,6 +56,7 @@ class Channel {
 
     void eraseOperator(Client *client);
     void eraseRegular(Client *client);
+    void eraseInvitedClient(Client *client);
 
     bool operator==(const Channel &other) const;
     bool operator!=(const Channel &other) const;

--- a/include/entity/Client.hpp
+++ b/include/entity/Client.hpp
@@ -16,9 +16,7 @@ class Client : public ConnectSocket {
     typedef std::set<Channel *>::iterator channel_list_iterator;
 
    private:
-    // typedef typename std::set<Channel *>::iterator channel_iterator;
-    ChannelList _channel_list;    // channel list
-    ChannelList _i_channel_list;  // invite channel list
+    ChannelList _channel_list;  // channel list
 
    public:
     Client(/* args*/);
@@ -31,8 +29,6 @@ class Client : public ConnectSocket {
 
     // update
     void insertChannel(Channel *channel);
-    void insertInviteChannel(Channel *channel);
-
     void eraseChannel(Channel *channel);
 
     // compare operators

--- a/include/handler/ResponseHandler.hpp
+++ b/include/handler/ResponseHandler.hpp
@@ -70,6 +70,10 @@ class ResponseHandler {
                                          std::vector<std::string> &operators,
                                          std::vector<std::string> &regulars);
 
+    static void handleInviteResponse(ConnectSocket *invitor,
+                                     ConnectSocket *target,
+                                     const std::string &channel_name);
+
     static void handleConnectResponse(ConnectSocket *src);
 
    private:

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -121,6 +121,10 @@ void ChannelController::insertRegular(Channel *channel, Client *client) {
     channel->insertRegular(client);
 }
 
+void ChannelController::insertInvitedClient(Channel *channel, Client *client) {
+    channel->insertInvitedClient(client);
+}
+
 /**
  * @brief erase Client to Channel's _clientList
  */

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -113,6 +113,12 @@ bool ChannelController::isRegular(Channel *channel, Client *client) {
     return regulars.find(client) != regulars.end() ? true : false;
 }
 
+bool ChannelController::isInvitedClient(Channel *channel, Client *client) {
+    std::set<Client *> invited_clients = channel->getInvitedClients();
+
+    return invited_clients.find(client) != invited_clients.end() ? true : false;
+}
+
 void ChannelController::insertOperator(Channel *channel, Client *client) {
     channel->insertOperator(client);
 }
@@ -144,6 +150,10 @@ void ChannelController::eraseClient(ChannelList &channel_list, Client *client) {
     for (; iter != channel_list.end(); ++iter) {
         eraseClient(*iter, client);
     }
+}
+
+void ChannelController::eraseInvitedClient(Channel *channel, Client *client) {
+    channel->eraseInvitedClient(client);
 }
 
 bool ChannelController::isInviteMode(const Channel *channel) {

--- a/src/controller/ChannelController.cpp
+++ b/src/controller/ChannelController.cpp
@@ -25,7 +25,6 @@ Channel *ChannelController::insert(const std::string &channel_name) {
     pair p = _channels.insert(std::make_pair(channel_name, Channel()));
     new_channel = &(p.first->second);
     new_channel->setName(channel_name);
-    new_channel->clearMode();
     return new_channel;
 }
 
@@ -144,15 +143,18 @@ void ChannelController::eraseClient(ChannelList &channel_list, Client *client) {
 }
 
 bool ChannelController::isInviteMode(const Channel *channel) {
-    return (channel->getMode() & (INVITE_ONLY_T - 1));
+    // return (channel->getMode() & (INVITE_ONLY_T - 1));
+    return (channel->getMode() & (1 << (INVITE_ONLY_T / 2)));
 }
 
 bool ChannelController::isTopicMode(const Channel *channel) {
-    return (channel->getMode() & (TOPIC_PRIV_T - 1));
+    // return (channel->getMode() & (TOPIC_PRIV_T - 1));
+    return (channel->getMode() & (1 << (TOPIC_PRIV_T / 2)));
 }
 
 bool ChannelController::isBanMode(const Channel *channel) {
-    return (channel->getMode() & (BAN_T - 1));
+    // return (channel->getMode() & (BAN_T - 1));
+    return (channel->getMode() & (1 << (BAN_T / 2)));
 }
 
 // private functions

--- a/src/controller/ClientController.cpp
+++ b/src/controller/ClientController.cpp
@@ -104,7 +104,7 @@ void ClientController::erase(int fd) {
 }
 
 void ClientController::updateClientStatus(int fd, Client *client,
-                                         e_status status) {
+                                          e_status status) {
     client->setStatus(status);
 }
 
@@ -114,20 +114,6 @@ void ClientController::updateClientStatus(int fd, Client *client,
  * @param fd
  * @param nickname
  */
-//void ClientController::updateNickname(int fd, const std::string &nickname) {
-//    Client *client = find(fd);
-
-//    if (client) {  // valid
-//        if (find(nickname)) {
-//            // no change (already exist)
-//        } else {
-//            // change nickname
-//            client->setNickname(nickname);
-//        }
-//    }
-//    // TODO error handling (잘못된 fd일 경우)
-//}
-
 void ClientController::updateNickname(Client *client,
                                       const std::string &nickname) {
     client->setNickname(nickname);
@@ -138,10 +124,6 @@ void ClientController::updateNickname(Client *client,
  */
 void ClientController::insertChannel(Client *client, Channel *channel) {
     client->insertChannel(channel);
-}
-
-void ClientController::insertInviteChannel(Client *client, Channel *channel) {
-    client->insertInviteChannel(channel);
 }
 
 /**

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -315,7 +315,7 @@ void Executor::invite(Client *invitor, params *params) {
         return;
     }
 
-    client_controller.insertInviteChannel(target, channel);
+    channel_controller.insertInvitedClient(channel, target);
     ResponseHandler::handleInviteResponse(invitor, target, channel_name);
     _client_list.insert(target);
 }

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -174,14 +174,12 @@ void Executor::join(Client *client, params *params) {
             return;
         } else if (channel_controller.isInviteMode(channel) &&
                    !channel_controller.isInvitedClient(channel, client)) {
-            // invite check
             ErrorHandler::handleError(client, *iter, ERR_INVITEONLYCHAN);
             return;
         } else {  // regular Client
             channel_controller.insertRegular(channel, client);
-            if (channel_controller.isInvitedClient(channel, client)) {
+            if (channel_controller.isInvitedClient(channel, client))
                 channel_controller.eraseInvitedClient(channel, client);
-            }
         }
         client_controller.insertChannel(client, channel);
 
@@ -237,23 +235,21 @@ void Executor::mode(Client *client, params *params) {
             ErrorHandler::handleError(client, param->nickname, ERR_NOSUCHNICK);
             return;
         }
-        if (!channel_controller.isOnChannel(channel, target)) {
-            ErrorHandler::handleError(client, param->nickname, ERR_NOSUCHNICK);
-            return;
-        }
         if (channel_controller.updateMode(mode, channel, target) == false) {
             return;
         }
-
+        response_msg = ResponseHandler::createResponse(
+            client, "MODE", channel_name + " " + mode_str[mode],
+            param->nickname);
     } else {  // +i, -i, +t, -t
         if (channel_controller.updateMode(mode, channel) == false) {
             return;
         }
+        response_msg = ResponseHandler::createResponse(
+            client, "MODE", channel_name, mode_str[mode]);
     }
 
     // response
-    response_msg = ResponseHandler::createResponse(client, "MODE", channel_name,
-                                                   mode_str[mode]);
     broadcast(channel, response_msg);
 }
 

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -172,11 +172,16 @@ void Executor::join(Client *client, params *params) {
             channel_controller.insertOperator(channel, client);
         } else if (channel_controller.isOnChannel(channel, client)) {
             return;
-        } else if (channel_controller.isInviteMode(channel)) {
+        } else if (channel_controller.isInviteMode(channel) &&
+                   !channel_controller.isInvitedClient(channel, client)) {
             // invite check
             ErrorHandler::handleError(client, *iter, ERR_INVITEONLYCHAN);
+            return;
         } else {  // regular Client
             channel_controller.insertRegular(channel, client);
+            if (channel_controller.isInvitedClient(channel, client)) {
+                channel_controller.eraseInvitedClient(channel, client);
+            }
         }
         client_controller.insertChannel(client, channel);
 

--- a/src/controller/Executor.cpp
+++ b/src/controller/Executor.cpp
@@ -172,6 +172,9 @@ void Executor::join(Client *client, params *params) {
             channel_controller.insertOperator(channel, client);
         } else if (channel_controller.isOnChannel(channel, client)) {
             return;
+        } else if (channel_controller.isInviteMode(channel)) {
+            // invite check
+            ErrorHandler::handleError(client, *iter, ERR_INVITEONLYCHAN);
         } else {  // regular Client
             channel_controller.insertRegular(channel, client);
         }
@@ -195,7 +198,6 @@ void Executor::join(Client *client, params *params) {
 
             client->send_buf.append(response_msg);
         }
-        // response_msg.clear();
     }
 }
 
@@ -288,7 +290,7 @@ void Executor::invite(Client *invitor, params *params) {
     invite_params *param = dynamic_cast<invite_params *>(params);
     std::string nickname = param->nickname;
     std::string channel_name = param->channel;
-    Client *client = client_controller.find(nickname);
+    Client *target = client_controller.find(nickname);
     Channel *channel = channel_controller.find(channel_name);
     std::string response_msg;
 
@@ -298,7 +300,7 @@ void Executor::invite(Client *invitor, params *params) {
         return;
     }
     // 401 nick2 hi :No such nick
-    if (client == NULL) {
+    if (target == NULL) {
         ErrorHandler::handleError(invitor, nickname, ERR_NOSUCHNICK);
         return;
     }
@@ -308,18 +310,14 @@ void Executor::invite(Client *invitor, params *params) {
         return;
     }
     // 482 nick2 #channel :You must be a channel op or higher to send an invite.
-    if (channel_controller.isOperator(channel, invitor)) {
+    if (!channel_controller.isOperator(channel, invitor)) {
         ErrorHandler::handleError(invitor, channel_name, ERR_CHANOPRIVSNEEDED);
         return;
     }
 
-    client_controller.insertInviteChannel(client, channel);
-    response_msg =
-        ResponseHandler::createResponse(invitor, "INVITE", RPL_INVITING);
-    broadcast(channel, response_msg, invitor);
-    response_msg =
-        ResponseHandler::createResponse(invitor, "INVITE", RPL_INVITING);
-    invitor->send_buf.append(response_msg);
+    client_controller.insertInviteChannel(target, channel);
+    ResponseHandler::handleInviteResponse(invitor, target, channel_name);
+    _client_list.insert(target);
 }
 
 void Executor::pass(Client *new_client, params *params,

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -7,12 +7,10 @@ namespace ft {
 Channel::Channel() {
     _mode = 0;
     setMode(TOPIC_PRIV_T);
-    setMode(INVITE_ONLY_F);
 }
 Channel::Channel(const std::string &name) : _name(name) {
     _mode = 0;
     setMode(TOPIC_PRIV_T);
-    setMode(INVITE_ONLY_F);
 }
 Channel::Channel(const Channel &copy) { *this = copy; }
 Channel::~Channel() {}

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -30,6 +30,9 @@ const std::string &Channel::getName() const { return _name; }
 const std::string &Channel::getTopic() const { return _topic; }
 const Channel::ClientList &Channel::getRegulars() const { return _regulars; }
 const Channel::ClientList &Channel::getOperators() const { return _operators; }
+const Channel::ClientList &Channel::getInvitedClients() const {
+    return _invited_clients;
+}
 int Channel::getMode() const { return _mode; }
 
 void Channel::setName(const std::string &name) { _name = name; }
@@ -61,6 +64,10 @@ void Channel::insertInvitedClient(Client *client) {
 void Channel::eraseOperator(Client *client) { _operators.erase(client); }
 
 void Channel::eraseRegular(Client *client) { _regulars.erase(client); }
+
+void Channel::eraseInvitedClient(Client *client) {
+    _invited_clients.erase(client);
+}
 
 bool Channel::operator==(const Channel &other) const {
     return (_name == other._name);

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -50,6 +50,10 @@ void Channel::insertOperator(Client *client) { _operators.insert(client); }
 
 void Channel::insertRegular(Client *client) { _regulars.insert(client); }
 
+void Channel::insertInvitedClient(Client *client) {
+    _invited_clients.insert(client);
+}
+
 // void Channel::eraseClient(Client *client, bool is_operator) {
 //     is_operator ? _operators.erase(client) : _regulars.erase(client);
 // }

--- a/src/entity/Channel.cpp
+++ b/src/entity/Channel.cpp
@@ -1,14 +1,20 @@
 #include "entity/Channel.hpp"
 
+#include "core/Type.hpp"
+
 namespace ft {
 
-Channel::Channel() : _mode(0) {}
-Channel::Channel(const std::string &name) : _name(name), _mode(0) {}
-Channel::Channel(const Channel &copy) {
-    if (*this != copy) {
-        *this = copy;
-    }
+Channel::Channel() {
+    _mode = 0;
+    setMode(TOPIC_PRIV_T);
+    setMode(INVITE_ONLY_F);
 }
+Channel::Channel(const std::string &name) : _name(name) {
+    _mode = 0;
+    setMode(TOPIC_PRIV_T);
+    setMode(INVITE_ONLY_F);
+}
+Channel::Channel(const Channel &copy) { *this = copy; }
 Channel::~Channel() {}
 Channel &Channel::operator=(const Channel &ref) {
     _name = ref._name;
@@ -34,8 +40,6 @@ void Channel::setMode(int mode) {
     else
         _mode &= ~(1 << (mode / 2));  // -flag
 }
-
-void Channel::clearMode() { _mode = 0; }
 
 // update
 // void Channel::insertClient(Client *client, bool is_operator) {

--- a/src/entity/Client.cpp
+++ b/src/entity/Client.cpp
@@ -18,9 +18,6 @@ const Client::ChannelList &Client::getChannelList() const {
 
 // update
 void Client::insertChannel(Channel *channel) { _channel_list.insert(channel); }
-void Client::insertInviteChannel(Channel *channel) {
-    _i_channel_list.insert(channel);
-}
 
 void Client::eraseChannel(Channel *channel) { _channel_list.erase(channel); }
 

--- a/src/handler/ErrorHandler.cpp
+++ b/src/handler/ErrorHandler.cpp
@@ -28,16 +28,16 @@ void ErrorHandler::handleError(ConnectSocket *src, std::string cause,
 }
 void ErrorHandler::handleError(std::exception &e, ConnectSocket *src) {
     if (Parser::UnknownCommandException *uce =
-        dynamic_cast<Parser::UnknownCommandException *>(&e))
+            dynamic_cast<Parser::UnknownCommandException *>(&e))
         handleError(src, uce->getCause(), ERR_UNKNOWNCOMMAND);
     else if (Parser::NotEnoughParamsException *nepe =
-        dynamic_cast<Parser::NotEnoughParamsException *>(&e))
+                 dynamic_cast<Parser::NotEnoughParamsException *>(&e))
         handleError(src, nepe->getCause(), ERR_NEEDMOREPARAMS);
     else if (Parser::InvalidChannelNameException *icne =
-        dynamic_cast<Parser::InvalidChannelNameException *>(&e))
+                 dynamic_cast<Parser::InvalidChannelNameException *>(&e))
         handleError(src, icne->getCause(), ERR_BADCHANMASK);
     else if (Parser::InvalidNickNameException *inne =
-        dynamic_cast<Parser::InvalidNickNameException *>(&e))
+                 dynamic_cast<Parser::InvalidNickNameException *>(&e))
         handleError(src, inne->getCause(), ERR_ERRONEUSNICKNAME);
     else
         std::cout << "ErrorHandler: Unknown error occurred" << std::endl;
@@ -99,7 +99,7 @@ const std::string ErrorHandler::ERR_USERONCHANNEL_MSG = "is already on channel";
 const std::string ErrorHandler::ERR_UNKNOWNMODE_MSG =
     "is unknown mode char to me";
 const std::string ErrorHandler::ERR_INVITEONLYCHAN_MSG =
-    "Cannot join channel (+i)";
+    "Cannot join channel (invite only)";
 const std::string ErrorHandler::ERR_CHANOPRIVSNEEDED_MSG =
     "You're not channel operator";
 const std::string ErrorHandler::ERR_NOSUCHNICK_MSG = "No such nick";

--- a/src/handler/ResponseHandler.cpp
+++ b/src/handler/ResponseHandler.cpp
@@ -111,6 +111,26 @@ std::string ResponseHandler::createJoinReponse(
     return res_stream.str();
 }
 
+void ResponseHandler::handleInviteResponse(ConnectSocket *invitor,
+                                           ConnectSocket *target,
+                                           const std::string &channel_name) {
+    std::stringstream invitor_res;
+    std::stringstream target_res;
+
+    invitor_res.fill('0');
+    target_res.fill('0');
+    // 341
+    invitor_res << invitor->getServername() << " " << RPL_INVITING << " "
+                << invitor->getNickname() << " " << target->getNickname()
+                << " :" << channel_name << std::endl;
+    invitor->send_buf.append(invitor_res.str());
+
+    target_res << ":" << invitor->getNickname() << "!" << invitor->getUsername()
+               << "@" << invitor->getServername() << " INVITE "
+               << target->getNickname() << " :" << channel_name << std::endl;
+    target->send_buf.append(target_res.str());
+}
+
 void ResponseHandler::handleConnectResponse(ConnectSocket *src) {
     const std::string prefix = src->getNickname() + "!" + src->getUsername() +
         "@" + src->getHostname();


### PR DESCRIPTION
## 개요
- invite, mode 관련 에러 처리

## 작업내용
- `ResponseHandler::handleInviteResponse` 함수 추가
- mode 초기화하는 부분 기존 `clearMode`에서 생성자로 수정
- `isInviteMode` 같은 mode 확인하는 함수 잘못된 연산 수정
- `JOIN`에서 채널에 들어갈 때 `invite` mode 확인하는 로직 추가
- `Client::_i_channel_list` -> `Channel::_invited_clients`로 수정 (관련한 insert, erase 함수들 함께 수정)
- `JOIN`에서 `Channel::_invited_clients` 업데이트하는 로직 추가

## 주의사항
- [x] join할 때 invite 채널인 경우 처리 다시 해야 함...